### PR TITLE
use 0.5.0 to fix the install of the colab code

### DIFF
--- a/examples/Spacy_Transformers_Demo.ipynb
+++ b/examples/Spacy_Transformers_Demo.ipynb
@@ -80,7 +80,7 @@
       "source": [
         "!pip install gputil\n",
         "!pip install torch==1.1.0\n",
-        "!pip install spacy-transformers[cuda100]==0.2.0\n",
+        "!pip install spacy-transformers[cuda100]==0.5.0\n",
         "!python -m spacy download en_trf_xlnetbasecased_lg\n",
         "!python -m spacy download en_trf_bertbaseuncased_lg"
       ],


### PR DESCRIPTION
The Colab demo was broken for me, changing spacy-tranformers to use version 0.5.0 seems to have fixed the issue (so far).