### PR TITLE
fixes model name referencing & ordering

### DIFF
--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -68,17 +68,17 @@ LANG_FACTORY = "trf"
 def get_config(name):
     """Map a name to the appropriate transformers.*Config class."""
     name = name.lower()
-    if "roberta" in name:
+    if name.startswith("roberta"):
         return transformers.RobertaConfig
-    elif "distilbert" in name:
+    elif name.startswith("distilbert"):
         return transformers.DistilBertConfig
-    elif "bert" in name:
+    elif name.startswith("bert"):
         return transformers.BertConfig
-    elif "xlnet" in name:
+    elif name.startswith("xlnet"):
         return transformers.XLNetConfig
-    elif "gpt2" in name:
+    elif name.startswith("gpt2"):
         return transformers.GPT2Config
-    elif "xlm" in name:
+    elif name.startswith("xlm"):
         return transformers.XLMConfig
     else:
         raise ValueError(f"Unsupported transformers config name: '{name}'")
@@ -87,17 +87,17 @@ def get_config(name):
 def get_model(name):
     """Map a name to the appropriate transformers.*Model class."""
     name = name.lower()
-    if "roberta" in name:
+    if name.startswith("roberta"):
         return transformers.RobertaModel
-    elif "distilbert" in name:
+    elif name.startswith("distilbert"):
         return transformers.DistilBertModel
-    elif "bert" in name:
+    elif name.startswith("bert"):
         return transformers.BertModel
-    elif "xlnet" in name:
+    elif name.startswith("xlnet"):
         return transformers.XLNetModel
-    elif "gpt2" in name:
+    elif name.startswith("gpt2"):
         return transformers.GPT2Model
-    elif "xlm" in name:
+    elif name.startswith("xlm"):
         return transformers.XLMModel
     else:
         raise ValueError(f"Unsupported transformers config name: '{name}'")
@@ -106,17 +106,17 @@ def get_model(name):
 def get_tokenizer(name):
     """Get a transformers.*Tokenizer class from a name."""
     name = name.lower()
-    if "roberta" in name:
+    if name.startswith("roberta"):
         return _tokenizers.SerializableRobertaTokenizer
-    elif "distilbert" in name:
+    elif name.startswith("distilbert"):
         return _tokenizers.SerializableDistilBertTokenizer
-    elif "bert" in name:
+    elif name.startswith("bert"):
         return _tokenizers.SerializableBertTokenizer
-    elif "xlnet" in name:
+    elif name.startswith("xlnet"):
         return _tokenizers.SerializableXLNetTokenizer
-    elif "gpt2" in name:
+    elif name.startswith("gpt2"):
         return _tokenizers.SerializableGPT2Tokenizer
-    elif "xlm" in name:
+    elif name.startswith("xlm"):
         return _tokenizers.SerializableXLMTokenizer
     else:
         raise ValueError(f"Unsupported transformers config name: '{name}'")
@@ -271,15 +271,15 @@ def get_segment_ids(name: str, *lengths) -> List[int]:
     else:
         msg = f"Expected 1 or 2 segments. Got {len(lengths)}"
         raise ValueError(msg)
-    if "bert" in name:
+    if name.startswith("bert"):
         return get_bert_segment_ids(length1, length2)
-    elif "xlnet" in name:
+    elif name.startswith("xlnet"):
         return get_xlnet_segment_ids(length1, length2)
-    elif "xlm" in name:
+    elif name.startswith("xlm"):
         return get_xlm_segment_ids(length1, length2)
-    elif "gpt2" in name:
+    elif name.startswith("gpt2"):
         return get_gpt2_segment_ids(length1, length2)
-    elif "roberta" in name:
+    elif name.startswith("roberta"):
         return get_roberta_segment_ids(length1, length2)
 
     else:

--- a/tests/test_textcat.py
+++ b/tests/test_textcat.py
@@ -13,11 +13,14 @@ def textcat(name, nlp, request):
     textcat = TransformersTextCategorizer(nlp.vocab, token_vector_width=width)
     textcat.add_label("Hello")
     config = {"architecture": arch, "trf_name": name}
-    if "gpt2" in name and arch in ("softmax_pooler_output", "softmax_class_vector"):
+    if name.startswith("gpt2") and arch in (
+        "softmax_pooler_output",
+        "softmax_class_vector",
+    ):
         with pytest.raises(ValueError):
             textcat.begin_training(**config)
         textcat.begin_training(trf_name=name, architecture="softmax_last_hidden")
-    elif "xlnet" in name and arch == "softmax_pooler_output":
+    elif name.startswith("xlnet") and arch == "softmax_pooler_output":
         with pytest.raises(ValueError):
             textcat.begin_training(**config)
         textcat.begin_training(trf_name=name, architecture="softmax_last_hidden")

--- a/tests/test_tok2vec.py
+++ b/tests/test_tok2vec.py
@@ -32,7 +32,7 @@ def test_set_annotations(name, tok2vec, docs):
     tok2vec.set_annotations(docs, scores)
     for doc in docs:
         assert doc._.get(ATTRS.last_hidden_state) is not None
-        if "bert" in name:
+        if name.startswith("bert"):
             assert doc._.get(ATTRS.pooler_output) is not None
         assert doc._.get(ATTRS.d_last_hidden_state) is not None
         assert doc._.get(ATTRS.d_last_hidden_state).ndim == 2


### PR DESCRIPTION
Referenced in this issue here: https://github.com/explosion/spacy-transformers/issues/96

This updates all code using the pattern `{model_name) in name` to use `name.startswith({model_name})`.

Following how models are named in https://github.com/huggingface/transformers#model-architectures, this should remove the need for concern about ordering whenever the set of possible models is referenced.

It also future proofs this against other future BERT-derivatives (like ALBERT), assuming that the transformers library keeps their naming convention of `{model_name}-{size}-{casing}`, and future BERT models have a prefix added (xxBERT) and not just a suffix (BERTxx).