### PR TITLE
define segment ids for distilbert

### DIFF
--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -273,6 +273,8 @@ def get_segment_ids(name: str, *lengths) -> List[int]:
         raise ValueError(msg)
     if name.startswith("bert"):
         return get_bert_segment_ids(length1, length2)
+    elif name.startswith("distilbert"):
+        return get_bert_segment_ids(length1, length2)
     elif name.startswith("xlnet"):
         return get_xlnet_segment_ids(length1, length2)
     elif name.startswith("xlm"):


### PR DESCRIPTION
PR #100 introduced a small bug for retrieving segment IDs by model name, because there was no line specifically for `distilbert` as it had a fall-through with the statement `if "bert" in name`. Now that it's more accurately `if name.startswith("bert")` we need to also add an `if` for `distilbert`. If not, running `train_textcat.py` with `en_trf_distilbertbaseuncased_lg` crashes. Note that all other places in the code did have a specific `if` statement for `distilbert` and are thus fine.

@honnibal : is it OK to call `get_bert_segment_ids` for `distilbert` or do we need a new method `get_distilbert_segment_ids` ?