### PR TITLE
Factory names for trf components

### DIFF
--- a/spacy_transformers/pipeline/ner.py
+++ b/spacy_transformers/pipeline/ner.py
@@ -13,6 +13,7 @@ class TransformersEntityRecognizer(spacy.pipeline.EntityRecognizer):
     """
 
     name = PIPES.ner
+    factory = PIPES.ner
 
     @classmethod
     def from_nlp(cls, nlp, **cfg):

--- a/spacy_transformers/pipeline/textcat.py
+++ b/spacy_transformers/pipeline/textcat.py
@@ -13,6 +13,7 @@ class TransformersTextCategorizer(spacy.pipeline.TextCategorizer):
     """
 
     name = PIPES.textcat
+    factory = PIPES.textcat
 
     @classmethod
     def from_nlp(cls, nlp, **cfg):

--- a/spacy_transformers/pipeline/tok2vec.py
+++ b/spacy_transformers/pipeline/tok2vec.py
@@ -22,6 +22,7 @@ class TransformersTok2Vec(Pipe):
     """
 
     name = PIPES.tok2vec
+    factory = PIPES.tok2vec
 
     @classmethod
     def from_nlp(cls, nlp, **cfg):

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -13,6 +13,7 @@ class TransformersWordPiecer(Pipe):
     only sets extension attributes and aligns the tokens."""
 
     name = PIPES.wordpiecer
+    factory = PIPES.wordpiecer
 
     @classmethod
     def from_nlp(cls, nlp, **cfg):


### PR DESCRIPTION
The `trf_textcat` component did not have a `factory` field defined, which made it fall back to `"textcat"`. This resulted in the `train_textcat.py` script crashing on IO because the `meta.json` had a factory entry reading `"trf_textcat":"textcat"` and then it was trying to create a wrong pipeline component.

Fixes #105 and fixes https://github.com/explosion/spaCy/issues/4701.

This PR also adds the `factory` field to the other new trf components.