### PR TITLE
Fix alignment algorithm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ srsly>=0.0.7,<1.1.0
 ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6,<0.7; python_version < "3.7"
 importlib_metadata>=0.20; python_version < "3.8"
-pytokenizations<0.2.0
+pytokenizations>=0.2.0
 # Testing
 pytest>=5.0.1,<5.1.0
 pytest-cov>=2.7.0,<2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ srsly>=0.0.7,<1.1.0
 ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6,<0.7; python_version < "3.7"
 importlib_metadata>=0.20; python_version < "3.8"
+pytokenizations<0.2.0
 # Testing
 pytest>=5.0.1,<5.1.0
 pytest-cov>=2.7.0,<2.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ install_requires =
     ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6,<0.7; python_version < "3.7"
     importlib_metadata>=0.20; python_version < "3.8"
+    pytokenizations<0.2.0
+
 setup_requires =
     setuptools
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6,<0.7; python_version < "3.7"
     importlib_metadata>=0.20; python_version < "3.8"
-    pytokenizations<0.2.0
+    pytokenizations>=0.2.0
 
 setup_requires =
     setuptools

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -110,10 +110,6 @@ class TransformersWordPiecer(Pipe):
         spacy_tokens = [w.text for w in segment]
         a2b, _ = get_alignments(spacy_tokens, wp_tokens)
 
-        # Head of wp_tokens is sometimes controll character (e.g. "_" for xlnet tokenizer),
-        # so insert 0 to head when it is missed.
-        if a2b and (not a2b[0] or a2b[0] != 0):
-            a2b[0].insert(0, 0)
         a2b = [[i + offset for i in a] for a in a2b]
         return wp_tokens, a2b
 

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -108,15 +108,15 @@ class TransformersWordPiecer(Pipe):
 
     def _align(self, segment, wp_tokens, *, offset=0):
         spacy_tokens = [w.text for w in segment]
-        a2b, _ = get_alignments(spacy_tokens, wp_tokens)
+        a2b, b2a = get_alignments(spacy_tokens, wp_tokens)
 
-        # Head of wp_tokens is sometimes controll character (e.g. "_" for xlnet tokenizer),
-        # so insert 0 to head when it is missed.
-        for a in a2b:
-            if a:
-                if a[0] != 0:
-                    a.insert(0, 0)
-                break
+        # a2b must contain the boundary of `segment` (head and last token index)
+        # so insert them when they are missed.
+        if a2b and b2a:
+            if len(b2a[0]) == 0:
+                a2b[0].insert(0, 0)
+            if len(b2a[-1]) == 0:
+                a2b[-1].append(len(b2a) - 1)
         a2b = [[i + offset for i in a] for a in a2b]
         return wp_tokens, a2b
 

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -109,6 +109,7 @@ class TransformersWordPiecer(Pipe):
     def _align(self, segment, wp_tokens, *, offset=0):
         spacy_tokens = [w.text for w in segment]
         a2b, _ = get_alignments(spacy_tokens, wp_tokens)
+        a2b = [[i + offset for i in a] for a in a2b]
         return wp_tokens, a2b
 
     def set_annotations(self, docs, outputs, tensors=None):

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -110,6 +110,13 @@ class TransformersWordPiecer(Pipe):
         spacy_tokens = [w.text for w in segment]
         a2b, _ = get_alignments(spacy_tokens, wp_tokens)
 
+        # Head of wp_tokens is sometimes controll character (e.g. "_" for xlnet tokenizer),
+        # so insert 0 to head when it is missed.
+        for a in a2b:
+            if a:
+                if a[0] != 0:
+                    a.insert(0, 0)
+                break
         a2b = [[i + offset for i in a] for a in a2b]
         return wp_tokens, a2b
 

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -109,6 +109,11 @@ class TransformersWordPiecer(Pipe):
     def _align(self, segment, wp_tokens, *, offset=0):
         spacy_tokens = [w.text for w in segment]
         a2b, _ = get_alignments(spacy_tokens, wp_tokens)
+
+        # Head of wp_tokens is sometimes controll character (e.g. "_" for xlnet tokenizer),
+        # so insert 0 to head when it is missed.
+        if a2b and (not a2b[0] or a2b[0] != 0):
+            a2b[0].insert(0, 0)
         a2b = [[i + offset for i in a] for a in a2b]
         return wp_tokens, a2b
 

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -130,6 +130,25 @@ class TransformersWordPiecer(Pipe):
             doc._.set(ATTRS.word_pieces_, wordpieces)
             doc._.set(ATTRS.word_pieces, self.model.convert_tokens_to_ids(wordpieces))
             doc._.set(ATTRS.alignment, alignment)
+            nr_word = len(doc._.get(ATTRS.word_pieces))
+            words_per_sent = sum(
+                len(sent._.get(ATTRS.word_pieces)) for sent in get_sents(doc)
+            )
+            if nr_word != words_per_sent:
+                print([repr(w.text) for w in doc])
+                for sent in get_sents(doc):
+                    print(sent._.get(ATTRS.word_pieces_))
+                    for w in sent:
+                        print(w.text, w._.get(ATTRS.alignment))
+                print(doc._.get(ATTRS.word_pieces_))
+                raise ValueError(
+                    f"Error calculating word pieces for sentences. Total number "
+                    f"of wordpieces in the doc was {nr_word}, but adding up the "
+                    f"wordpieces for its sentences we get {words_per_sent}. This "
+                    f"means there's a bug in the extension attributes or "
+                    f"the tokenizer.add_special_tokens() logic, often when "
+                    f"a spaCy sentence aligns against 0 wordpieces."
+                )
         self.model.max_len = max_len
 
     def use_params(self, params):

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -125,25 +125,6 @@ class TransformersWordPiecer(Pipe):
             doc._.set(ATTRS.word_pieces_, wordpieces)
             doc._.set(ATTRS.word_pieces, self.model.convert_tokens_to_ids(wordpieces))
             doc._.set(ATTRS.alignment, alignment)
-            nr_word = len(doc._.get(ATTRS.word_pieces))
-            words_per_sent = sum(
-                len(sent._.get(ATTRS.word_pieces)) for sent in get_sents(doc)
-            )
-            if nr_word != words_per_sent:
-                print([repr(w.text) for w in doc])
-                for sent in get_sents(doc):
-                    print(sent._.get(ATTRS.word_pieces_))
-                    for w in sent:
-                        print(w.text, w._.get(ATTRS.alignment))
-                print(doc._.get(ATTRS.word_pieces_))
-                raise ValueError(
-                    f"Error calculating word pieces for sentences. Total number "
-                    f"of wordpieces in the doc was {nr_word}, but adding up the "
-                    f"wordpieces for its sentences we get {words_per_sent}. This "
-                    f"means there's a bug in the extension attributes or "
-                    f"the tokenizer.add_special_tokens() logic, often when "
-                    f"a spaCy sentence aligns against 0 wordpieces."
-                )
         self.model.max_len = max_len
 
     def use_params(self, params):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -21,9 +21,34 @@ def test_wordpiecer(wp):
     assert "".join(cleaned_words) == "".join(words)
 
 
+@pytest.mark.parametrize(
+    "words,target_name,expected_align",
+    [
+        (
+            ["hello", "world", "this", "is", "a", "teest"],
+            "bert-base-uncased",
+            [[1], [2], [3], [4], [5], [6, 7]],
+        ),
+        (
+            ["hello", "world", "this", "is", "a", "teest"],
+            "xlnet-base-cased",
+            [[0], [1], [2], [3], [4], [5, 6]],
+        ),
+        (["å\taa", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]]),
+        (["å\taa", "が\nπ"], "bert-base-uncased", [[1, 2], [3, 4]]),
+    ],
+)
+def test_align(wp, name, words, target_name, expected_align):
+    if name != target_name:
+        pytest.skip()
+    doc = Doc(wp.vocab, words=words)
+    doc = wp(doc)
+    assert doc._.get(ATTRS.alignment) == expected_align
+
+
 def test_xlnet_weird_align(name, wp):
     if "xlnet" not in name.lower():
-        return True
+        pytest.skip()
     text = "Well, i rented this movie and found out it realllllllly sucks."
     spacy_tokens = [
         "Well",

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -41,7 +41,7 @@ def test_wordpiecer(wp):
             [[0], [1], [2], [3], [4], [5, 6]],
         ),
         (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]]),
-        (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3, 4]]),
+        (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -43,6 +43,7 @@ def test_wordpiecer(wp):
         (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
         (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [7, 8, 10]]),
         (["\u3099"], "bert-base-uncased", [[]]),
+        (["I.\n\n\n\n\n"], "bert-base-uncased", [[1, 2]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -30,18 +30,18 @@ def test_wordpiecer(wp):
 @pytest.mark.parametrize(
     "words,target_name,expected_align",
     [
-        # (
-        #     ["hello", "world", "this", "is", "a", "teest"],
-        #     "bert-base-uncased",
-        #     [[1], [2], [3], [4], [5], [6, 7]],
-        # ),
-        # (
-        #     ["hello", "world", "this", "is", "a", "teest"],
-        #     "xlnet-base-cased",
-        #     [[0], [1], [2], [3], [4], [5, 6]],
-        # ),
-        # (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]])
-        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]])
+        (
+            ["hello", "world", "this", "is", "a", "teest"],
+            "bert-base-uncased",
+            [[1], [2], [3], [4], [5], [6, 7]],
+        ),
+        (
+            ["hello", "world", "this", "is", "a", "teest"],
+            "xlnet-base-cased",
+            [[0], [1], [2], [3], [4], [5, 6]],
+        ),
+        (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
+        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [8, 10]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -3,11 +3,17 @@ from spacy_transformers import TransformersWordPiecer
 from spacy_transformers.util import is_special_token, get_tokenizer, ATTRS
 from spacy.vocab import Vocab
 from spacy.tokens import Doc
+from spacy.pipeline import Sentencizer
 
 
 @pytest.fixture(scope="session")
 def wp(name):
     return TransformersWordPiecer.from_pretrained(Vocab(), trf_name=name)
+
+
+@pytest.fixture(scope="session")
+def sentencizer():
+    return Sentencizer()
 
 
 def test_wordpiecer(wp):
@@ -38,10 +44,11 @@ def test_wordpiecer(wp):
         (["å\taa", "が\nπ"], "bert-base-uncased", [[1, 2], [3, 4]]),
     ],
 )
-def test_align(wp, name, words, target_name, expected_align):
+def test_align(wp, sentencizer, name, words, target_name, expected_align):
     if name != target_name:
         pytest.skip()
     doc = Doc(wp.vocab, words=words)
+    doc = sentencizer(doc)
     doc = wp(doc)
     assert doc._.get(ATTRS.alignment) == expected_align
 

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -42,6 +42,7 @@ def test_wordpiecer(wp):
         ),
         (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
         (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [7, 8, 10]]),
+        (["\u3099"], "bert-base-uncased", [[]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -41,7 +41,7 @@ def test_wordpiecer(wp):
             [[0], [1], [2], [3], [4], [5, 6]],
         ),
         (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
-        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [8, 10]]),
+        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [7, 8, 10]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -40,8 +40,8 @@ def test_wordpiecer(wp):
             "xlnet-base-cased",
             [[0], [1], [2], [3], [4], [5, 6]],
         ),
-        (["å\taa", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]]),
-        (["å\taa", "が\nπ"], "bert-base-uncased", [[1, 2], [3, 4]]),
+        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]]),
+        (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3, 4]]),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -30,18 +30,18 @@ def test_wordpiecer(wp):
 @pytest.mark.parametrize(
     "words,target_name,expected_align",
     [
-        (
-            ["hello", "world", "this", "is", "a", "teest"],
-            "bert-base-uncased",
-            [[1], [2], [3], [4], [5], [6, 7]],
-        ),
-        (
-            ["hello", "world", "this", "is", "a", "teest"],
-            "xlnet-base-cased",
-            [[0], [1], [2], [3], [4], [5, 6]],
-        ),
-        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]]),
-        (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]]),
+        # (
+        #     ["hello", "world", "this", "is", "a", "teest"],
+        #     "bert-base-uncased",
+        #     [[1], [2], [3], [4], [5], [6, 7]],
+        # ),
+        # (
+        #     ["hello", "world", "this", "is", "a", "teest"],
+        #     "xlnet-base-cased",
+        #     [[0], [1], [2], [3], [4], [5, 6]],
+        # ),
+        # (["å\taa", ".", "が\nπ"], "bert-base-uncased", [[1, 2], [3], [6, 7]])
+        (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4, 6]])
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):


### PR DESCRIPTION
From #87 

FIx the below method with [pytokenizations](https://github.com/tamuhey/tokenizations), which is I created for this purpose.

https://github.com/explosion/spacy-transformers/blob/378d6aa9c33acaf8970e607733b85f83bf8a61f5/spacy_transformers/pipeline/wordpiecer.py#L108

This library is based on "shortest edit script" and can handle noisy tokenizations, for example:

```python
a = ["げん", "ご"]
b = ["けんこ"] # all accents are dropped (が -> か, ご -> こ)
a2b = [[0], [0]]
b2a = [[0, 1]]
assert tokenizations.get_alignments(a, b) == (a2b, b2a)
```

(I thinks this library is useful for `spacy.align` function. see https://github.com/explosion/spaCy/issues/4554)