### PR TITLE
Fix attention mask for padded inputs

### DIFF
--- a/spacy_transformers/activations.py
+++ b/spacy_transformers/activations.py
@@ -73,6 +73,8 @@ class RaggedArray:
         # and avoid the loop
         shape = (len(self.lengths), to) + self.data.shape[1:]
         values = self.xp.zeros(shape, dtype=self.dtype)
+        if value != 0:
+            values.fill(value)
         if self.data.size == 0:
             return values
         mask = lengths2mask(self.lengths)

--- a/spacy_transformers/wrapper.py
+++ b/spacy_transformers/wrapper.py
@@ -177,7 +177,7 @@ class TransformersWrapper(PyTorchWrapper):
         return Activations(lh, po)
 
     def get_model_kwargs(self, inputs):
-        padded = inputs.to_padded()
+        padded = inputs.to_padded(value=-1)
         if padded.ndim == 2:
             padded = padded.reshape(padded.shape + (1,))
         if self.max_length:
@@ -188,6 +188,7 @@ class TransformersWrapper(PyTorchWrapper):
         ids = torch.as_tensor(ids, dtype=torch.int64)
         if padded.shape[2] == 2:
             segment_ids = padded[:, :, 1]
+            numpy.place(segment_ids, segment_ids<0, 0)
             segment_ids = torch.as_tensor(segment_ids, dtype=torch.int64)
         else:
             segment_ids = torch.zeros_like(ids)


### PR DESCRIPTION
Fix `RaggedArray.to_padded()` to pad using the provided value.

In `TransformersWrapper.get_model_kwargs()`, pad with `-1` in order to be able to create the correct `attention_mask`.

Addresses inconsistent results due to batching reported in #132 and #135.