### PR TITLE
Update for transformers v2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy>=2.2.1,<2.3.0
-transformers>=2.0.0,<2.1.0
+transformers>=2.5.0,<2.6.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0
 srsly>=0.0.7,<1.1.0


### PR DESCRIPTION
Since I was already looking at the newer transformers API, I think these are the changes that would be required for transformers v2.5.0.

The tests pass and the test script from https://github.com/explosion/spacy-transformers/pull/136#issuecomment-590074921 works with the plain transformers models after applying the patches in #136 and #137, but I'm not familiar enough with everything to know whether there are additional details I might have missed.