### PR TITLE
Lower transformers lower version pin to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy>=2.2.1,<2.3.0
-transformers>=2.5.0,<2.6.0
+transformers>=2.4.0,<2.6.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0
 srsly>=0.0.7,<1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     spacy>=2.2.1,<2.3.0
-    transformers>=2.0.0,<2.1.0
+    transformers>=2.4.0,<2.6.0
     torch>=1.0.0
     torchcontrib>=0.0.2,<0.1.0
     srsly>=0.0.7,<1.1.0


### PR DESCRIPTION
`PreTrainedTokenizer.unique_added_tokens_encoder`, the most recent relevant change in `transformers`, was introduced in `2.4.0`.