### PR TITLE
Bump spacy to v2.3.0 for v0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy>=2.2.1,<2.3.0
+spacy>=2.3.0,<2.4.0
 transformers>=2.4.0,<2.6.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    spacy>=2.2.1,<2.3.0
+    spacy>=2.3.0,<2.4.0
     transformers>=2.4.0,<2.6.0
     torch>=1.0.0
     torchcontrib>=0.0.2,<0.1.0


### PR DESCRIPTION
The spacy-transformers model versions are currently tied to the spacy versions, so the upcoming release of v2.3.0 offers a way to handle incompatible spacy-transformers models for v0.6.0.