### PR TITLE
fix align indices in split_by_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package (previously `spacy-pytorch-transformers`) provides
 package, so you can use them in spaCy. The result is convenient access to
 state-of-the-art transformer architectures, such as BERT, GPT-2, XLNet, etc.
 
-[![Azure Pipelines](https://img.shields.io/azure-devops/build/explosion-ai/public/11/master.svg?logo=azure-pipelines&style=flat-square)](https://dev.azure.com/explosion-ai/public/_build?definitionId=11)
+[![Azure Pipelines](https://img.shields.io/azure-devops/build/explosion-ai/public/18/master.svg?logo=azure-pipelines&style=flat-square)](https://dev.azure.com/explosion-ai/public/_build?definitionId=18)
 [![PyPi](https://img.shields.io/pypi/v/spacy-transformers.svg?style=flat-square&logo=pypi&logoColor=white)](https://pypi.python.org/pypi/spacy-transformers)
 [![GitHub](https://img.shields.io/github/release/explosion/spacy-transformers/all.svg?style=flat-square&logo=github)](https://github.com/explosion/spacy-transformers/releases)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/ambv/black)

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -68,17 +68,24 @@ class FullTransformerBatch:
         token_positions = get_token_positions(flat_spans)
         outputs = []
         start = 0
+        prev_tokens = 0
         for doc_spans in self.spans:
             start_i = token_positions[doc_spans[0][0]]
             end_i = token_positions[doc_spans[-1][-1]] + 1
             end = start + len(doc_spans)
+            doc_tokens = slice_hf_tokens(self.tokens, start, end)
+            doc_tensors = [torch2xp(t[start:end]) for t in self.tensors]
+            doc_align = self.align[start_i:end_i]
+            doc_align.data = doc_align.data - prev_tokens
             outputs.append(
                 TransformerData(
-                    tokens=slice_hf_tokens(self.tokens, start, end),
-                    tensors=[torch2xp(t[start:end]) for t in self.tensors],  # type: ignore
-                    align=self.align[start_i:end_i],
+                    tokens=doc_tokens,
+                    tensors=doc_tensors,  # type: ignore
+                    align=doc_align,
                 )
             )
+            token_count = len(doc_tokens["input_texts"][0])
+            prev_tokens += token_count
             start += len(doc_spans)
         return outputs
 

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -7,6 +7,7 @@ from spacy.vocab import Vocab
 from spacy.gold import Example
 from spacy import util
 from spacy.util import minibatch, eg2doc, link_vectors_to_models
+from spacy_transformers.util import huggingface_from_pretrained
 from thinc.api import Model, set_dropout_rate
 
 import srsly


### PR DESCRIPTION
When calling `split_by_doc` the `Ragged` object `self.align` is sliced, which works for the lengths, but not for the indices stored in  `Ragged.data`, because they would refer to tokens outside the document. 

This bugfix keeps track of how many TRF tokens there were in previous docs (`prev_tokens`), and deduces those from the indexing vector.