### PR TITLE
Fix tokenizers serialization for spacy v2.3.0

### DIFF
--- a/spacy_transformers/_tokenizers.py
+++ b/spacy_transformers/_tokenizers.py
@@ -69,13 +69,13 @@ class SerializationMixin:
         return srsly.msgpack_dumps(msg)
 
     def from_disk(self, path, exclude=tuple(), **kwargs):
-        with (path / "transformers_tokenizer.msg").open("rb") as file_:
+        with path.open("rb") as file_:
             data = file_.read()
         return self.from_bytes(data, **kwargs)
 
     def to_disk(self, path, exclude=tuple(), **kwargs):
         data = self.to_bytes(**kwargs)
-        with (path / "transformers_tokenizer.msg").open("wb") as file_:
+        with path.open("wb") as file_:
             file_.write(data)
 
 


### PR DESCRIPTION
Write to the provided path rather than writing to a subdirectory.

(I'm not sure what caused this regression and I don't really understand how it worked before, since it wrote to `model` and not `model/transformers_tokenizer.msg` in previous saved models.)