### PR TITLE
Fix wordpiecer truncation to be per sentence

### DIFF
--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -98,11 +98,18 @@ class TransformersWordPiecer(Pipe):
                     seg_words, seg_align = self._align(
                         segment, seg_words, offset=offset
                     )
+                    # max_seq_length per sentence is calculated relative to the
+                    # index of the first aligned segment within the sentence
+                    align_start_id = 0
+                    for align in seg_align:
+                        if len(align) >= 1:
+                            align_start_id = align[0]
+                            break
                     seg_words = seg_words[:max_seq_length]
                     for i, align in enumerate(seg_align):
-                        if len(align) >= 1 and align[-1] < max_seq_length:
+                        if len(align) >= 1 and align[-1] < align_start_id + max_seq_length:
                             continue
-                        seg_align[i] = [x for x in align if x < max_seq_length]
+                        seg_align[i] = [x for x in align if x < align_start_id + max_seq_length]
                     assert len(segment) == len(seg_align)
                     sent_words.append(seg_words)
                     sent_align.append(seg_align)

--- a/spacy_transformers/pipeline/wordpiecer.py
+++ b/spacy_transformers/pipeline/wordpiecer.py
@@ -107,9 +107,14 @@ class TransformersWordPiecer(Pipe):
                             break
                     seg_words = seg_words[:max_seq_length]
                     for i, align in enumerate(seg_align):
-                        if len(align) >= 1 and align[-1] < align_start_id + max_seq_length:
+                        if (
+                            len(align) >= 1
+                            and align[-1] < align_start_id + max_seq_length
+                        ):
                             continue
-                        seg_align[i] = [x for x in align if x < align_start_id + max_seq_length]
+                        seg_align[i] = [
+                            x for x in align if x < align_start_id + max_seq_length
+                        ]
                     assert len(segment) == len(seg_align)
                     sent_words.append(seg_words)
                     sent_align.append(seg_align)

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -46,7 +46,14 @@ def test_wordpiecer(wp):
         (["I.\n\n\n\n\n"], "bert-base-uncased", [[1, 2]]),
         # max length of 512 minus 2 special tokens -> 510 aligned tokens,
         # remaining truncated per sentence
-        (["x"] * 599 + ["."] + ["y"] * 600, "bert-base-uncased", [[x] for x in range(1, 511)] + [[]] * 90 + [[x] for x in range(513, 1023)] + [[]] * 90),
+        (
+            ["x"] * 599 + ["."] + ["y"] * 600,
+            "bert-base-uncased",
+            [[x] for x in range(1, 511)]
+            + [[]] * 90
+            + [[x] for x in range(513, 1023)]
+            + [[]] * 90,
+        ),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):

--- a/tests/test_wordpiecer.py
+++ b/tests/test_wordpiecer.py
@@ -44,6 +44,9 @@ def test_wordpiecer(wp):
         (["å\taa", ".", "が\nπ"], "xlnet-base-cased", [[0, 1, 2], [4], [7, 8, 10]]),
         (["\u3099"], "bert-base-uncased", [[]]),
         (["I.\n\n\n\n\n"], "bert-base-uncased", [[1, 2]]),
+        # max length of 512 minus 2 special tokens -> 510 aligned tokens,
+        # remaining truncated per sentence
+        (["x"] * 599 + ["."] + ["y"] * 600, "bert-base-uncased", [[x] for x in range(1, 511)] + [[]] * 90 + [[x] for x in range(513, 1023)] + [[]] * 90),
     ],
 )
 def test_align(wp, sentencizer, name, words, target_name, expected_align):


### PR DESCRIPTION
Fix wordpiecer truncation so that each sentence is truncated individually rather than truncating full documents at the max sequence length.

Fixes #193.