### PR TITLE
Store model_type in tok2vec cfg

### DIFF
--- a/spacy_transformers/model_registry.py
+++ b/spacy_transformers/model_registry.py
@@ -43,7 +43,7 @@ def get_model_function(name: str):
 @register_model("tok2vec_per_sentence")
 def tok2vec_per_sentence(model_name, cfg):
     max_words = cfg.get("words_per_batch", 1000)
-    name = cfg["trf_name"]
+    name = cfg["trf_model_type"]
 
     model = foreach_sentence(
         chain(get_word_pieces(name), with_length_batching(model_name, max_words))

--- a/spacy_transformers/pipeline/tok2vec.py
+++ b/spacy_transformers/pipeline/tok2vec.py
@@ -9,6 +9,7 @@ from ..wrapper import TransformersWrapper
 from ..model_registry import get_model_function
 from ..activations import Activations, RaggedArray
 from ..util import get_config, get_model, get_sents, PIPES, ATTRS
+from ..util import get_config_name
 
 
 class TransformersTok2Vec(Pipe):
@@ -56,6 +57,7 @@ class TransformersTok2Vec(Pipe):
         name = cfg.get("trf_name")
         if not name:
             raise ValueError(f"Need trf_name argument, e.g. 'bert-base-uncased'")
+        cfg["trf_model_type"] = get_config_name(cfg.get("trf_name"))
         if cfg.get("from_pretrained"):
             wrap = TransformersWrapper.from_pretrained(name)
         else:

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -280,7 +280,6 @@ def get_segment_ids(name: str, *lengths) -> List[int]:
     else:
         msg = f"Expected 1 or 2 segments. Got {len(lengths)}"
         raise ValueError(msg)
-    name = get_config_name(name)
     if name.startswith("bert"):
         return get_bert_segment_ids(length1, length2)
     elif name.startswith("distilbert"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,12 @@ import pytest
 from spacy_transformers import TransformersLanguage, TransformersWordPiecer
 from spacy_transformers import TransformersTok2Vec
 
-MODEL_NAMES = ["bert-base-uncased", "gpt2", "xlnet-base-cased"]
+MODEL_NAMES = [
+    "bert-base-uncased",
+    "gpt2",
+    "xlnet-base-cased",
+    "sshleifer/tiny-distilbert-base-cased",
+]
 
 
 @pytest.fixture(scope="session", params=MODEL_NAMES)


### PR DESCRIPTION
Store `trf_model_type` in the `TransformersTok2Vec` config for use with `get_segment_ids`.

Add a model to test suite with a `trf_name` that does not start with model type.

Fixes #204.