### PR TITLE
Renaming annotation_setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Python code.
 ```
 [nlp.pipeline.transformer]
 factory = "transformer"
-extra_annotation_setter = null
+set_extra_annotations = null
 max_batch_size = 32
 
 [nlp.pipeline.transformer.model]
@@ -96,7 +96,7 @@ trf = Transformer(
         get_spans=get_doc_spans,
         tokenizer_config={"use_fast": True},
     ),
-    annotation_setter=null_annotation_setter,
+    set_extra_annotations=null_annotation_setter,
     max_batch_size=32,
 )
 nlp.add_pipe("transformer", trf, first=True)
@@ -166,7 +166,7 @@ via the `Transformer` pipeline component. This sets the `doc._.trf_data` extensi
 attribute, which lets you access the transformers outputs at runtime via the
 `doc._.trf_data` extension attribute. You can also customize how the
 `Transformer` object sets annotations onto the `Doc`, by customizing the 
-`Transformer.annotation_setter` object. This callback will be called with the
+`Transformer.set_extra_annotations` function. This callback will be called with the
 raw input and output data for the whole batch, along with the batch of `Doc`
 objects, allowing you to implement whatever you need.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy-nightly>=3.0.0a0,<3.0.0a20
+spacy-nightly>=3.0.0a16,<3.0.0a20
 transformers>=3.0.0,<3.1.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy-nightly>=3.0.0a16,<3.0.0a20
+spacy-nightly>=3.0.0a0,<3.0.0a20
 transformers>=3.0.0,<3.1.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    spacy-nightly>=3.0.0a16
+    spacy-nightly>=3.0.0a0
     transformers>=3.0.0,<3.1.0
     thinc>=8.0.0a11
     torch>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    spacy-nightly>=3.0.0a0
+    spacy-nightly>=3.0.0a16
     transformers>=3.0.0,<3.1.0
     thinc>=8.0.0a11
     torch>=1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.0.0a8
+version = 1.0.0a9
 description = spaCy pipelines for pre-trained BERT and other transformers
 url = https://spacy.io
 author = Explosion

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -4,7 +4,7 @@ from spacy.language import Language
 from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
-from spacy.gold import Example
+from spacy.training import Example
 from spacy import util
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -4,7 +4,7 @@ from spacy.language import Language
 from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
-from spacy.training import Example
+from spacy.gold import Example
 from spacy import util
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -50,6 +50,21 @@ def test_set_annotations(component, docs):
         assert isinstance(doc._.trf_data, TransformerData)
 
 
+def test_set_extra_annotations(component, docs):
+    Doc.set_extension("custom_attr", default="")
+
+    def custom_annotation_setter(docs, trf_data):
+        doc_data = list(trf_data.doc_data)
+        for doc, data in zip(docs, doc_data):
+            doc._.custom_attr = data
+
+    component.set_extra_annotations = custom_annotation_setter
+    trf_data = component.predict(docs)
+    component.set_annotations(docs, trf_data)
+    for doc in docs:
+        assert isinstance(doc._.custom_attr, TransformerData)
+
+
 def test_listeners(component, docs):
     docs = list(component.pipe(docs))
     for listener in component.listeners:

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -29,7 +29,7 @@ def component(vocab):
 def test_init(component):
     assert isinstance(component.vocab, Vocab)
     assert isinstance(component.model, Model)
-    assert hasattr(component.annotation_setter, "__call__")
+    assert hasattr(component.set_extra_annotations, "__call__")
     assert component.listeners == []
     assert component.cfg == {"max_batch_items": 4096}
 


### PR DESCRIPTION
Linked PR: https://github.com/explosion/spaCy/pull/6042 -> can be merged once this one is merged

## Description
- rename  `annotation_setter` to `set_extra_annotations`, to be consistent with `get_spans` while avoiding conflict with the normal `set_annotations` `Pipe` methods.
- bump to 1.0.0a9