### PR TITLE
rename gold to training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy-nightly>=3.0.0a0,<3.0.0a20
+spacy-nightly>=3.0.0a16,<3.0.0a20
 transformers>=3.0.0,<3.1.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    spacy-nightly>=3.0.0a0
+    spacy-nightly>=3.0.0a16
     transformers>=3.0.0,<3.1.0
     thinc>=8.0.0a11
     torch>=1.0.0

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -4,7 +4,7 @@ from spacy.language import Language
 from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
-from spacy.gold import Example
+from spacy.training import Example
 from spacy import util
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer


### PR DESCRIPTION
To be merged once [spacy-nightly 3.0.0a16](https://github.com/explosion/spaCy/pull/6042) is released.

## Description
- rename spacy's directory `gold` to `training`