### PR TITLE
Check for empty list of listeners

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy-nightly>=3.0.0a26,<3.0.0a30
+spacy-nightly>=3.0.0a27,<3.0.0a30
 transformers>=3.0.0,<3.1.0
 torch>=1.0.0
 torchcontrib>=0.0.2,<0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    spacy-nightly>=3.0.0a26,<3.0.0a30
+    spacy-nightly>=3.0.0a27,<3.0.0a30
     transformers>=3.0.0,<3.1.0
     thinc>=8.0.0a11
     torch>=1.0.0

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -280,7 +280,8 @@ class Transformer(Pipe):
         batch_id = TransformerListener.get_batch_id(docs)
         for listener in self.listeners[:-1]:
             listener.receive(batch_id, trf_full.doc_data, accumulate_gradient)
-        self.listeners[-1].receive(batch_id, trf_full.doc_data, backprop)
+        if self.listeners:
+            self.listeners[-1].receive(batch_id, trf_full.doc_data, backprop)
         if set_annotations:
             self.set_annotations(docs, trf_full)
         return losses

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -90,7 +90,7 @@ def test_transformer_pipeline_simple():
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
 
-    optimizer = nlp.begin_training()
+    optimizer = nlp.initialize()
     for i in range(2):
         losses = {}
         nlp.update(train_examples, sgd=optimizer, losses=losses)
@@ -142,7 +142,7 @@ def test_transformer_pipeline_tagger():
 
     # Check that the Transformer component finds it listeners
     assert transformer.listeners == []
-    optimizer = nlp.begin_training(lambda: train_examples)
+    optimizer = nlp.initialize(lambda: train_examples)
     assert tagger_trf in transformer.listeners
 
     for i in range(2):


### PR DESCRIPTION
Bugfix to allow a spaCy pipeline with a transformer but not a `TransformerListener`. 
Added some more "complex" unit tests for testing the transformer as part of a larger spaCy pipeline.