### PR TITLE
Robustness to empty docs

### DIFF
--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -134,21 +134,25 @@ class FullTransformerBatch:
         start = 0
         prev_tokens = 0
         for doc_spans in self.spans:
-            start_i = token_positions[doc_spans[0][0]]
-            end_i = token_positions[doc_spans[-1][-1]] + 1
-            end = start + len(doc_spans)
-            doc_tokens = slice_hf_tokens(self.tokens, start, end)
-            doc_tensors = [torch2xp(t[start:end]) for t in self.tensors]
-            doc_align = self.align[start_i:end_i]
-            doc_align.data = doc_align.data - prev_tokens
-            outputs.append(
-                TransformerData(
-                    tokens=doc_tokens,
-                    tensors=doc_tensors,  # type: ignore
-                    align=doc_align,
+            if len(doc_spans) == 0 or len(doc_spans[0]) == 0:
+                outputs.append(TransformerData.empty())
+                token_count = 0
+            else:
+                start_i = token_positions[doc_spans[0][0]]
+                end_i = token_positions[doc_spans[-1][-1]] + 1
+                end = start + len(doc_spans)
+                doc_tokens = slice_hf_tokens(self.tokens, start, end)
+                doc_tensors = [torch2xp(t[start:end]) for t in self.tensors]
+                doc_align = self.align[start_i:end_i]
+                doc_align.data = doc_align.data - prev_tokens
+                outputs.append(
+                    TransformerData(
+                        tokens=doc_tokens,
+                        tensors=doc_tensors,  # type: ignore
+                        align=doc_align,
+                    )
                 )
-            )
-            token_count = sum(len(texts) for texts in doc_tokens["input_texts"])
+                token_count = sum(len(texts) for texts in doc_tokens["input_texts"])
             prev_tokens += token_count
             start += len(doc_spans)
         return outputs

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -93,6 +93,13 @@ class FullTransformerBatch:
     align: Ragged
     _doc_data: Optional[List[TransformerData]] = None
 
+    @classmethod
+    def empty(cls, nr_docs) -> "FullTransformerBatch":
+        spans = [[] for i in range(nr_docs)]
+        doc_data = [TransformerData.empty() for i in range(nr_docs)]
+        align = Ragged(numpy.zeros((0,), dtype="i"), numpy.zeros((0,), dtype="i"))
+        return cls(spans=spans, tokens={}, tensors=[], align=align, _doc_data=doc_data)
+
     @property
     def doc_data(self) -> List[TransformerData]:
         """The outputs, split per spaCy Doc object."""

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -11,7 +11,7 @@ def trfs2arrays(
 ) -> Model[List[TransformerData], List[Floats2d]]:
     """Pool transformer data into token-aligned tensors."""
     return Model(
-        "trfs2arrays", forward, layers=[pooling], attrs={"grad_factor": grad_factor},
+        "trfs2arrays", forward, layers=[pooling], attrs={"grad_factor": grad_factor}
     )
 
 
@@ -28,6 +28,8 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             output, get_d_dst = pooling(dst, is_train)
             outputs.append(output)
             backprops.append((get_d_dst, get_d_src))
+        else:
+            outputs.append(model.ops.alloc2f(0, 0))
 
     def backprop_trf_to_tensor(d_outputs: List[Floats2d]) -> List[TransformerData]:
         d_trf_datas = []
@@ -43,9 +45,10 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             d_tensors[t_i] = d_src.reshape(trf_data.tensors[t_i].shape)
             d_trf_datas.append(
                 TransformerData(
-                    tensors=d_tensors, tokens=trf_data.tokens, align=trf_data.align,
+                    tensors=d_tensors, tokens=trf_data.tokens, align=trf_data.align
                 )
             )
         return d_trf_datas
 
+    assert len(outputs) == len(trf_datas)
     return outputs, backprop_trf_to_tensor


### PR DESCRIPTION
Various tests & fixes to deal with empty docs

- prevent sending empty `texts` through HF `tokenizer.batch_encode_plus`
- ensure that `trf2arrays` can deal with empty data
- ensure that `split_by_doc` doesn't crash if `self.spans` contains an empty list