### PR TITLE
add upstream argument to TransformerListener.v1

### DIFF
--- a/spacy_transformers/architectures.py
+++ b/spacy_transformers/architectures.py
@@ -9,7 +9,7 @@ from .util import registry
 
 @registry.architectures.register("spacy-transformers.TransformerListener.v1")
 def transformer_listener_tok2vec_v1(
-    pooling: Model[Ragged, Floats2d], grad_factor: float = 1.0
+    pooling: Model[Ragged, Floats2d], grad_factor: float = 1.0, upstream: str = "*"
 ) -> Model[List[Doc], List[Floats2d]]:
     """Create a 'TransformerListener' layer, which will connect to a Transformer
     component earlier in the pipeline.
@@ -30,8 +30,16 @@ def transformer_listener_tok2vec_v1(
         them upstream. You can set this to 0 to "freeze" the transformer weights
         with respect to the component, or use it to make some components more
         significant than others. Leaving it at 1.0 is usually fine.
+    upstream (str): A string to identify the 'upstream' Transformer
+        to communicate with. The upstream name should either be the wildcard
+        string '*', or the name of the `Transformer` component. You'll almost
+        never have multiple upstream Transformer components, so the wildcard
+        string will almost always be fine.
     """
-    return chain(TransformerListener("transformer"), trfs2arrays(pooling, grad_factor),)
+    return chain(
+        TransformerListener(upstream_name=upstream),
+        trfs2arrays(pooling, grad_factor)
+    )
 
 
 @registry.architectures.register("spacy-transformers.Tok2VecTransformer.v1")

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -116,12 +116,14 @@ cfg_string = """
     [components.tagger.model.tok2vec]
     @architectures = "spacy-transformers.TransformerListener.v1"
     grad_factor = 1.0
+    upstream = ${components.transformer.name}
     
     [components.tagger.model.tok2vec.pooling]
     @layers = "reduce_mean.v1"
 
     [components.transformer]
     factory = "transformer"
+    name = "custom_upstream"
     """
 
 
@@ -135,6 +137,7 @@ def test_transformer_pipeline_tagger():
     tagger_trf = tagger.model.get_ref("tok2vec").layers[0]
     assert isinstance(transformer, Transformer)
     assert isinstance(tagger_trf, TransformerListener)
+    assert tagger_trf.upstream_name == "custom_upstream"
     train_examples = []
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))


### PR DESCRIPTION
Added `upstream` argument to `TransformerListener.v1`

I don't think we need to bump the version of `TransformerListener`, as the config file will still be valid without this argument, as there is a default?