### PR TITLE
Switch from pytokenizations to spacy-alignments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ srsly>=2.0.1,<3.0.0
 ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6; python_version < "3.7"
 importlib_metadata>=0.20; python_version < "3.8"
-pytokenizations>=0.2.0
+spacy-alignments>=0.7.2,<1.0.0
 # Testing
 pytest>=5.0.1,<5.1.0
 pytest-cov>=2.7.0,<2.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6; python_version < "3.7"
     importlib_metadata>=0.20; python_version < "3.8"
-    pytokenizations>=0.2.0
+    spacy-alignments>=0.7.2,<1.0.0
 
 setup_requires =
     setuptools

--- a/spacy_transformers/align.py
+++ b/spacy_transformers/align.py
@@ -1,6 +1,6 @@
 import numpy
 from typing import cast, Dict, List, Tuple, Callable, Set
-import tokenizations
+from spacy_alignments.tokenizations import get_alignments
 from spacy.tokens import Span, Token
 from thinc.api import Ops
 from thinc.types import Ragged, Floats2d, Ints1d
@@ -142,7 +142,7 @@ def get_alignment(spans: List[Span], wordpieces: List[List[str]]) -> Ragged:
     wp_start = 0
     for i, (span, wp_toks) in enumerate(zip(spans, wordpieces)):
         sp_toks = [token.text for token in span]
-        span2wp, wp2span = tokenizations.get_alignments(sp_toks, wp_toks)
+        span2wp, wp2span = get_alignments(sp_toks, wp_toks)
         for token, wp_js in zip(span, span2wp):
             position = token_positions[token]
             alignment[position].update(wp_start + j for j in wp_js)


### PR DESCRIPTION
The underlying Rust library and Python bindings should be identical.