### PR TITLE
Skip special tokens during alignment

### DIFF
--- a/spacy_transformers/align.py
+++ b/spacy_transformers/align.py
@@ -144,7 +144,14 @@ def get_alignment(spans: List[Span], wordpieces: List[List[str]], special_tokens
     wp_start = 0
     for i, (span, wp_toks) in enumerate(zip(spans, wordpieces)):
         sp_toks = [token.text for token in span]
-        wp_toks_filtered = [tok if tok not in special_tokens else "" for tok in wp_toks]
+        wp_toks_filtered = wp_toks
+        # In the case that the special tokens do not appear in the text, filter
+        # them out for alignment purposes so that special tokens like "<s>" are
+        # not aligned to the character "s" in the text. (If the special tokens
+        # appear in the text, it's not possible to distinguish them from the
+        # added special tokens, so they may be aligned incorrectly.)
+        if not any([special in span.text for special in special_tokens]):
+            wp_toks_filtered = [tok if tok not in special_tokens else "" for tok in wp_toks]
         span2wp, wp2span = get_alignments(sp_toks, wp_toks_filtered)
         for token, wp_js in zip(span, span2wp):
             position = token_positions[token]

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -116,7 +116,7 @@ def forward(
     # if "offset_mapping" in token_data and hasattr(token_data, "char_to_token"):
     #    align = get_alignment_via_offset_mapping(flat_spans, token_data)
     # else:
-    align = get_alignment(flat_spans, token_data["input_texts"])
+    align = get_alignment(flat_spans, token_data["input_texts"], model.attrs["tokenizer"].all_special_tokens)
     output = FullTransformerBatch(
         spans=nested_spans, tokens=token_data, tensors=tensors, align=align
     )

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -17,6 +17,10 @@ class DummyTokenizer:
         self.start_symbol = "<s>"
         self.end_symbol = "</s>"
 
+    @property
+    def all_special_tokens(self):
+        return [self.start_symbol, self.end_symbol]
+
     def batch_encode_plus(
         self,
         texts,


### PR DESCRIPTION
Skip special tokens during alignment, because otherwise the alignment algorithm does things like trying to align the `s` in `<s>` to the character `s` in a token in the text, unless any of the special tokens are found in the text itself.

The tokenizer doesn't distinguish added special tokens from special tokens in the text, so it's not possible to distinguish them during alignment, either:

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("roberta-base")
assert tokenizer.batch_encode_plus(["<s>"], add_special_tokens=True)["input_ids"] == [[0, 0, 2]]
```