### PR TITLE
Update for compat with transformers>=4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy-nightly>=3.0.0a39,<3.1.0
-transformers>=3.0.0,<4.0.0
+transformers>=3.0.0,<4.2.0
 torch>=1.5.0
 torchcontrib>=0.0.2,<0.1.0
 srsly>=2.0.1,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     spacy-nightly>=3.0.0a39,<3.1.0
-    transformers>=3.0.0,<4.0.0
+    transformers>=3.0.0,<4.2.0
     torch>=1.5.0
     torchcontrib>=0.0.2,<0.1.0
     srsly>=2.0.1,<3.0.0

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -147,6 +147,8 @@ def _convert_transformer_inputs(model, tokens: BatchEncoding, is_train):
 
 def _convert_transformer_outputs(model, inputs_outputs, is_train):
     _, tensors = inputs_outputs
+    if hasattr(tensors, "to_tuple"):
+        tensors = tensors.to_tuple()
 
     def backprop(d_tensors: List[torch.Tensor]) -> ArgsKwargs:
         return ArgsKwargs(args=(tensors,), kwargs={"grad_tensors": d_tensors})


### PR DESCRIPTION
Convert `ModelOutput` to tuple format for compatible processing of output with transformers v3 and v4.