### PR TITLE
Update to-be-deprecated tokenizer usage

### DIFF
--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -17,14 +17,14 @@ class DummyTokenizer:
         self.start_symbol = "<s>"
         self.end_symbol = "</s>"
 
-    def batch_encode_plus(
+    def __call__(
         self,
         texts,
         add_special_tokens=True,
         max_length=None,
         stride: int = 0,
         truncation_strategy="longest_first",
-        pad_to_max_length=False,
+        padding=False,
         is_pretokenized=False,
         return_tensors=None,
         return_token_type_ids=None,

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -38,7 +38,7 @@ def huggingface_from_pretrained(source: Union[Path, str], config: Dict):
 
 def huggingface_tokenize(tokenizer, texts: List[str]) -> BatchEncoding:
     """Apply a Huggingface tokenizer to a batch of texts."""
-    token_data = tokenizer.batch_encode_plus(
+    token_data = tokenizer(
         texts,
         add_special_tokens=True,
         return_attention_mask=True,
@@ -46,7 +46,7 @@ def huggingface_tokenize(tokenizer, texts: List[str]) -> BatchEncoding:
         return_offsets_mapping=isinstance(tokenizer, PreTrainedTokenizerFast),
         return_tensors="pt",
         return_token_type_ids=None,  # Sets to model default
-        pad_to_max_length=True,
+        padding="longest",
     )
     token_data["input_texts"] = [
         tokenizer.convert_ids_to_tokens(list(ids)) for ids in token_data["input_ids"]


### PR DESCRIPTION
Update to call the tokenizer directly and to switch from the deprected `pad_to_max_length` to the equivalent `padding="longest"`.