### PR TITLE
Update transformers dependency to support v4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy-nightly>=3.0.0a39,<3.1.0
-transformers>=3.0.0,<4.2.0
+transformers>=3.0.0,<4.3.0
 torch>=1.5.0
 torchcontrib>=0.0.2,<0.1.0
 srsly>=2.0.1,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     spacy-nightly>=3.0.0a39,<3.1.0
-    transformers>=3.0.0,<4.2.0
+    transformers>=3.0.0,<4.3.0
     torch>=1.5.0
     torchcontrib>=0.0.2,<0.1.0
     srsly>=2.0.1,<3.0.0


### PR DESCRIPTION
Update transformers to support v4.2. From their [release notes](https://github.com/huggingface/transformers/releases/tag/v4.2.0):

> ## Breaking changes
> There are no breaking changes between the previous version and this one.
> This will be the first version to require TensorFlow >= 2.3.