### PR TITLE
Raise lower pin for transformers to 3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spacy-nightly>=3.0.0a39,<3.1.0
-transformers>=3.0.0,<4.3.0
+transformers>=3.1.0,<4.3.0
 torch>=1.5.0
 torchcontrib>=0.0.2,<0.1.0
 srsly>=2.0.1,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     spacy-nightly>=3.0.0a39,<3.1.0
-    transformers>=3.0.0,<4.3.0
+    transformers>=3.1.0,<4.3.0
     torch>=1.5.0
     torchcontrib>=0.0.2,<0.1.0
     srsly>=2.0.1,<3.0.0


### PR DESCRIPTION
Raise lower pin for transformers to 3.1.0 because of changes in how the text lengths are returned from the tokenizer.