### PR TITLE
Truncate oversize wordpiece segments after alignment, before transformer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.0.0rc2
+version = 1.0.0rc3.dev0
 description = spaCy pipelines for pre-trained BERT and other transformers
 url = https://spacy.io
 author = Explosion

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.0.0rc3.dev0
+version = 1.0.0rc3
 description = spaCy pipelines for pre-trained BERT and other transformers
 url = https://spacy.io
 author = Explosion

--- a/spacy_transformers/align.py
+++ b/spacy_transformers/align.py
@@ -100,7 +100,11 @@ def get_alignment_via_offset_mapping(spans: List[Span], token_data) -> Ragged:
     return align
 
 
-def get_alignment(spans: List[Span], wordpieces: List[List[str]], special_tokens: Optional[List[str]] = None) -> Ragged:
+def get_alignment(
+    spans: List[Span],
+    wordpieces: List[List[str]],
+    special_tokens: Optional[List[str]] = None,
+) -> Ragged:
     """Compute a ragged alignment array that records, for each unique token in
     `spans`, the corresponding indices in the flattened `wordpieces` array.
     For instance, imagine you have two overlapping spans:
@@ -151,7 +155,9 @@ def get_alignment(spans: List[Span], wordpieces: List[List[str]], special_tokens
         # appear in the text, it's not possible to distinguish them from the
         # added special tokens, so they may be aligned incorrectly.)
         if not any([special in span.text for special in special_tokens]):
-            wp_toks_filtered = [tok if tok not in special_tokens else "" for tok in wp_toks]
+            wp_toks_filtered = [
+                tok if tok not in special_tokens else "" for tok in wp_toks
+            ]
         span2wp, wp2span = get_alignments(sp_toks, wp_toks_filtered)
         for token, wp_js in zip(span, span2wp):
             position = token_positions[token]

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict
+from typing import Optional, List
 import torch
 import numpy
 from transformers.tokenization_utils import BatchEncoding
-from thinc.types import Ragged, Floats3d, FloatsXd
+from thinc.types import Ragged, Floats3d, FloatsXd, Ints2d
 from thinc.api import get_array_module, xp2torch, torch2xp
 from spacy.tokens import Span
 
-from .util import slice_hf_tokens, transpose_list
+from .util import transpose_list
 from .align import get_token_positions
 
 

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -12,6 +12,66 @@ from .align import get_token_positions
 
 
 @dataclass
+class WordpieceBatch:
+    """Holds data from the transformers BatchEncoding class.
+
+    We would have preferred to use the BatchEncoding class directly, but
+    there's a few problems with that.
+    
+    1. Some BatchEncoding functionality requires the tokenizers.Encoding object,
+        and it's impossible for us to create or manipulate that object. This means
+        we can't really create BatchEncoding objects, which limits what we can do.
+    2. We want some semantic differences, for instance the "lengths" data in the
+        BatchEncoding is useless when the inputs are padded. We want it to tell
+        us the *unpadded* lengths.
+    3. We want typed attributes, so that we can type-check properly.
+    4. We prefer to have numpy/cupy arrays rather than torch arrays.
+    5. The API around the BatchEncoding object has been changing a lot, so we
+        want to minimize the places where we touch it.
+    """
+    strings: List[List[str]]
+    input_ids: Ints2d
+    input_type_ids: Ints2d
+    attention_mask: Floats3d
+    lengths: List[int]
+
+    def __len__(self) -> int:
+        return len(self.strings)
+
+    def __getitem__(self, index) -> "WordpieceBatch":
+        if isinstance(index, int):
+            slice_ = slice(index, index+1)
+        else:
+            slice_ = index
+        return WordpieceBatch(
+            strings=self.strings[slice_],
+            input_ids=self.input_ids[slice_],
+            attention_mask=self.attention_mask[slice_],
+            lengths=self.lengths[slice_]
+        )
+
+    @classmethod
+    def zeros(cls, lengths: List[int]) -> "WordpieceBatch":
+        # TODO
+        ...
+
+    @classmethod
+    def from_batch_encoding(cls, token_data: BatchEncoding) -> "WordpieceBatch":
+        pad_token = token_data.get("pad_token", "[PAD]")
+        lengths = [
+            len([tok for tok in tokens if tok != pad_token])
+            for tokens in token_data["input_texts"]
+        ]
+        return cls(
+            strings=token_data["input_texts"],
+            input_ids=torch2xp(token_data["input_ids"]),
+            input_type_ids=torch2xp(token_data["input_type_ids"]),
+            attention_mask=torch2xp(token_data["attention_mask"]),
+            lengths=lengths
+        )
+
+
+@dataclass
 class TransformerData:
     """Transformer tokens and outputs for one Doc object.
     
@@ -37,7 +97,7 @@ class TransformerData:
         wordpiece tokens that token i aligns against. The actual indices are
         provided at align[i].dataXd.
     """
-    tokens: Dict
+    tokens: WordpieceBatch
     tensors: List[FloatsXd]
     align: Ragged
 
@@ -51,7 +111,7 @@ class TransformerData:
         """Create a valid TransformerData container for a given shape, filled
         with zeros."""
         return cls(
-            tokens={"input_ids": numpy.zeros((length,), dtype="i")},
+            tokens=WordpieceBatch.zeros([length]),
             tensors=[xp.zeros((1, length, width), dtype="f")],
             align=Ragged(numpy.arange(length), numpy.ones((length,), dtype="i"))
         )
@@ -80,7 +140,7 @@ class FullTransformerBatch:
         within a Doc, the regions of the output tensors that correspond to each
         Span may overlap or have gaps, but for each Doc, there is a non-overlapping
         contiguous slice of the outputs.
-    tokens (BatchEncoding): The output of the Huggingface tokenizer.
+    tokens (WordpieceBatch): The output of the Huggingface tokenizer.
     tensors (List[torch.Tensor]): The output of the transformer model.
     align (Ragged): Alignment from the spaCy tokenization to the wordpieces.
         This is a ragged array, where align.lengths[i] indicates the number of
@@ -88,7 +148,7 @@ class FullTransformerBatch:
         provided at align[i].dataXd.
     """
     spans: List[List[Span]]
-    tokens: BatchEncoding
+    tokens: WordpieceBatch
     tensors: List[torch.Tensor]
     align: Ragged
     cached_doc_data: Optional[List[TransformerData]] = None
@@ -141,7 +201,7 @@ class FullTransformerBatch:
                 start_i = token_positions[doc_spans[0][0]]
                 end_i = token_positions[doc_spans[-1][-1]] + 1
                 end = start + len(doc_spans)
-                doc_tokens = slice_hf_tokens(self.tokens, start, end)
+                doc_tokens = self.tokens[start:end]
                 doc_tensors = [torch2xp(t[start:end]) for t in self.tensors]
                 doc_align = self.align[start_i:end_i]
                 doc_align.data = doc_align.data - prev_tokens
@@ -152,7 +212,7 @@ class FullTransformerBatch:
                         align=doc_align,
                     )
                 )
-                token_count = sum(len(texts) for texts in doc_tokens["input_texts"])
+                token_count = sum(doc_tokens.lengths)
             prev_tokens += token_count
             start += len(doc_spans)
         return outputs

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -57,9 +57,13 @@ class WordpieceBatch:
         )
 
     @classmethod
-    def zeros(cls, lengths: List[int]) -> "WordpieceBatch":
-        # TODO
-        ...
+    def zeros(cls, lengths: List[int], xp=numpy) -> "WordpieceBatch":
+        return cls(
+            strings=[[""] * length for length in lengths],
+            input_ids=xp.array([[0] * length for length in lengths], dtype="i"),
+            attention_mask=xp.ones((len(lengths), max(lengths)), dtype="bool"),
+            lengths=lengths
+        )
 
     @classmethod
     def from_batch_encoding(cls, token_data: BatchEncoding) -> "WordpieceBatch":

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -29,6 +29,7 @@ class WordpieceBatch:
     5. The API around the BatchEncoding object has been changing a lot, so we
         want to minimize the places where we touch it.
     """
+
     strings: List[List[str]]
     input_ids: Ints2d
     input_type_ids: Ints2d
@@ -40,14 +41,14 @@ class WordpieceBatch:
 
     def __getitem__(self, index) -> "WordpieceBatch":
         if isinstance(index, int):
-            slice_ = slice(index, index+1)
+            slice_ = slice(index, index + 1)
         else:
             slice_ = index
         return WordpieceBatch(
             strings=self.strings[slice_],
             input_ids=self.input_ids[slice_],
             attention_mask=self.attention_mask[slice_],
-            lengths=self.lengths[slice_]
+            lengths=self.lengths[slice_],
         )
 
     @classmethod
@@ -67,7 +68,7 @@ class WordpieceBatch:
             input_ids=torch2xp(token_data["input_ids"]),
             input_type_ids=torch2xp(token_data["input_type_ids"]),
             attention_mask=torch2xp(token_data["attention_mask"]),
-            lengths=lengths
+            lengths=lengths,
         )
 
 
@@ -97,6 +98,7 @@ class TransformerData:
         wordpiece tokens that token i aligns against. The actual indices are
         provided at align[i].dataXd.
     """
+
     tokens: WordpieceBatch
     tensors: List[FloatsXd]
     align: Ragged
@@ -113,7 +115,7 @@ class TransformerData:
         return cls(
             tokens=WordpieceBatch.zeros([length]),
             tensors=[xp.zeros((1, length, width), dtype="f")],
-            align=Ragged(numpy.arange(length), numpy.ones((length,), dtype="i"))
+            align=Ragged(numpy.arange(length), numpy.ones((length,), dtype="i")),
         )
 
     @property
@@ -147,6 +149,7 @@ class FullTransformerBatch:
         wordpiece tokens that token i aligns against. The actual indices are
         provided at align[i].dataXd.
     """
+
     spans: List[List[Span]]
     tokens: WordpieceBatch
     tensors: List[torch.Tensor]
@@ -158,7 +161,9 @@ class FullTransformerBatch:
         spans = [[] for i in range(nr_docs)]
         doc_data = [TransformerData.empty() for i in range(nr_docs)]
         align = Ragged(numpy.zeros((0,), dtype="i"), numpy.zeros((0,), dtype="i"))
-        return cls(spans=spans, tokens={}, tensors=[], align=align, cached_doc_data=doc_data)
+        return cls(
+            spans=spans, tokens={}, tensors=[], align=align, cached_doc_data=doc_data
+        )
 
     @property
     def doc_data(self) -> List[TransformerData]:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -32,7 +32,7 @@ class WordpieceBatch:
 
     strings: List[List[str]]
     input_ids: Ints2d
-    input_type_ids: Ints2d
+    token_type_ids: Ints2d
     attention_mask: Floats3d
     lengths: List[int]
 
@@ -47,6 +47,7 @@ class WordpieceBatch:
         return WordpieceBatch(
             strings=self.strings[slice_],
             input_ids=self.input_ids[slice_],
+            token_type_ids=self.token_type_ids[slice_],
             attention_mask=self.attention_mask[slice_],
             lengths=self.lengths[slice_],
         )
@@ -66,7 +67,7 @@ class WordpieceBatch:
         return cls(
             strings=token_data["input_texts"],
             input_ids=torch2xp(token_data["input_ids"]),
-            input_type_ids=torch2xp(token_data["input_type_ids"]),
+            token_type_ids=torch2xp(token_data["token_type_ids"]),
             attention_mask=torch2xp(token_data["attention_mask"]),
             lengths=lengths,
         )

--- a/spacy_transformers/layers/listener.py
+++ b/spacy_transformers/layers/listener.py
@@ -63,8 +63,7 @@ def forward(model: TransformerListener, docs, is_train):
         elif any(doc._.trf_data is None for doc in docs):
             width = model.get_dim("nO")
             outputs = [
-                TransformerData.zeros(len(doc), width, xp=model.ops.xp)
-                for doc in docs
+                TransformerData.zeros(len(doc), width, xp=model.ops.xp) for doc in docs
             ]
         else:
             outputs = [doc._.trf_data for doc in docs]

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -143,7 +143,7 @@ def forward(
     if "logger" in model.attrs:
         log_gpu_memory(model.attrs["logger"], "after forward")
     output = FullTransformerBatch(
-        spans=nested_spans, tokens=wordpieces, tensors=tensors, align=align
+        spans=nested_spans, wordpieces=wordpieces, tensors=tensors, align=align
     )
     if "logger" in model.attrs:
         log_gpu_memory(model.attrs["logger"], "return from forward")
@@ -159,14 +159,14 @@ def forward(
     return output, backprop_transformer
 
 
-def _convert_transformer_inputs(model, tokens: WordpieceBatch, is_train):
+def _convert_transformer_inputs(model, wps: WordpieceBatch, is_train):
     # Adapter for the PyTorchWrapper. See https://thinc.ai/docs/usage-frameworks
     kwargs = {
-        "input_ids": xp2torch(tokens.input_ids),
-        "attention_mask": xp2torch(tokens.attention_mask),
+        "input_ids": xp2torch(wps.input_ids),
+        "attention_mask": xp2torch(wps.attention_mask),
     }
-    if tokens.token_type_ids:
-        kwargs["token_type_ids"] = xp2torch(tokens.token_type_ids)
+    if wps.token_type_ids:
+        kwargs["token_type_ids"] = xp2torch(wps.token_type_ids)
     return ArgsKwargs(args=(), kwargs=kwargs), lambda dX: []
 
 

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -112,14 +112,10 @@ def forward(
     if "logger" in model.attrs:
         log_batch_size(model.attrs["logger"], wordpieces, is_train)
     align = get_alignment(
-        flat_spans,
-        wordpieces.strings,
-        model.attrs["tokenizer"].all_special_tokens
+        flat_spans, wordpieces.strings, model.attrs["tokenizer"].all_special_tokens
     )
     wordpieces, align = truncate_oversize_splits(
-        wordpieces,
-        align,
-        tokenizer.model_max_length
+        wordpieces, align, tokenizer.model_max_length
     )
     tensors, bp_tensors = transformer(wordpieces, is_train)
     if "logger" in model.attrs:

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -45,7 +45,9 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             d_tensors[t_i] = d_src.reshape(trf_data.tensors[t_i].shape)
             d_trf_datas.append(
                 TransformerData(
-                    tensors=d_tensors, tokens=trf_data.tokens, align=trf_data.align
+                    tensors=d_tensors,
+                    wordpieces=trf_data.wordpieces,
+                    align=trf_data.align
                 )
             )
         return d_trf_datas

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -60,7 +60,7 @@ def test_predict(component, docs):
     trf_data = component.predict(docs)
     assert isinstance(trf_data, FullTransformerBatch)
     assert len(trf_data.tensors) == component.model.layers[0].attrs["depth"]
-    n_tokens = trf_data.tokens["input_ids"].shape[1]
+    n_tokens = trf_data.tokens.input_ids.shape[1]
     width = component.model.layers[0].attrs["width"]
     assert trf_data.tensors[-1].shape == (len(docs), n_tokens, width)
 
@@ -106,10 +106,10 @@ def test_transformer_pipeline_simple(simple_nlp):
 
 
 def test_transformer_pipeline_long_token(simple_nlp):
-    """Test that a simple pipeline raises an error on a text that exceeds the
-    model max length."""
-    with pytest.raises(ValueError):
-        doc = simple_nlp("https://example.com/" + "a/" * 1000)
+    """Test that a simple pipeline does not raise an error on texts that exceeds
+    the model max length. We should truncate instead.
+    """
+    doc = simple_nlp("https://example.com/" + "a/" * 1000)
 
 
 cfg_string = """

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -223,7 +223,8 @@ def test_transformer_pipeline_empty():
 
 
 def _assert_empty(trf_data):
-    empty = TransformerData.empty()
-    assert trf_data.wordpieces == empty.wordpieces
-    assert trf_data.tensors == empty.tensors
+    assert trf_data.wordpieces.strings == []
+    assert trf_data.wordpieces.input_ids.size == 0
+    assert trf_data.wordpieces.attention_mask.size == 0
+    assert trf_data.tensors == []
     assert len(trf_data.align.data) == 0

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -60,7 +60,7 @@ def test_predict(component, docs):
     trf_data = component.predict(docs)
     assert isinstance(trf_data, FullTransformerBatch)
     assert len(trf_data.tensors) == component.model.layers[0].attrs["depth"]
-    n_tokens = trf_data.tokens.input_ids.shape[1]
+    n_tokens = trf_data.wordpieces.input_ids.shape[1]
     width = component.model.layers[0].attrs["width"]
     assert trf_data.tensors[-1].shape == (len(docs), n_tokens, width)
 
@@ -224,6 +224,6 @@ def test_transformer_pipeline_empty():
 
 def _assert_empty(trf_data):
     empty = TransformerData.empty()
-    assert trf_data.tokens == empty.tokens
+    assert trf_data.wordpieces == empty.wordpieces
     assert trf_data.tensors == empty.tensors
     assert len(trf_data.align.data) == 0

--- a/spacy_transformers/tests/test_spanners.py
+++ b/spacy_transformers/tests/test_spanners.py
@@ -46,7 +46,7 @@ def test_get_custom_spans():
                         start += max_length
                         end += max_length
                     if start < len(sent):
-                        spans[-1].append(sent[start:len(sent)])
+                        spans[-1].append(sent[start : len(sent)])
             return spans
 
         return get_custom_sent_spans

--- a/spacy_transformers/tests/test_truncation.py
+++ b/spacy_transformers/tests/test_truncation.py
@@ -9,11 +9,12 @@ from thinc.api import NumpyOps
 def sequences():
     # Each sequence is a list of tokens, and each token is a number of wordpieces
     return [
-        [1, 3, 1],    # So 5 wordpieces this sequence
-        [3, 7, 1, 1], # 12
-        [1],          # 1
-        [20, 1],      # 21
+        [1, 3, 1],  # So 5 wordpieces this sequence
+        [3, 7, 1, 1],  # 12
+        [1],  # 1
+        [20, 1],  # 21
     ]
+
 
 @pytest.fixture
 def shape(sequences):
@@ -35,7 +36,7 @@ def align(sequences):
     for seq in sequences:
         for token_length in seq:
             lengths.append(token_length)
-            indices.extend(i+offset for i in range(token_length))
+            indices.extend(i + offset for i in range(token_length))
             offset += token_length
     return Ragged(numpy.array(indices, dtype="i"), numpy.array(lengths, dtype="i"))
 
@@ -49,21 +50,21 @@ def max_length():
 def mask_from_end(shape, max_length):
     n_seq, length = shape
     bools = [
-        numpy.array([(i+1) < max_length for i in range(length)], dtype="bool")
+        numpy.array([(i + 1) < max_length for i in range(length)], dtype="bool")
         for _ in range(n_seq)
     ]
     return numpy.concatenate(bools)
 
 
 def test_truncate_alignment_from_end(sequences, max_length, align, mask_from_end):
-    #print("Max length", max_length)
-    #print("Sequences", sequences)
-    #print("Mask", mask_from_end)
+    # print("Max length", max_length)
+    # print("Sequences", sequences)
+    # print("Mask", mask_from_end)
     ops = NumpyOps()
     truncated = _truncate_alignment(align, mask_from_end)
-    #print(truncated.dataXd.shape, truncated.lengths.sum())
-    #print("Before", list(map(list, ops.unflatten(align.dataXd, align.lengths))))
-    #print("After", list(map(list, ops.unflatten(truncated.dataXd, truncated.lengths))))
+    # print(truncated.dataXd.shape, truncated.lengths.sum())
+    # print("Before", list(map(list, ops.unflatten(align.dataXd, align.lengths))))
+    # print("After", list(map(list, ops.unflatten(truncated.dataXd, truncated.lengths))))
     # Check that the number of tokens hasn't changed. We still need to have
     # alignment for every token.
     assert truncated.lengths.shape[0] == align.lengths.shape[0]

--- a/spacy_transformers/tests/test_truncation.py
+++ b/spacy_transformers/tests/test_truncation.py
@@ -1,0 +1,88 @@
+import pytest
+import numpy
+from spacy_transformers.truncate import _truncate_tokens, _truncate_alignment
+from thinc.types import Ragged
+from thinc.api import NumpyOps
+
+
+@pytest.fixture
+def sequences():
+    # Each sequence is a list of tokens, and each token is a number of wordpieces
+    return [
+        [1, 3, 1],    # So 5 wordpieces this sequence
+        [3, 7, 1, 1], # 12
+        [1],          # 1
+        [20, 1],      # 21
+    ]
+
+@pytest.fixture
+def shape(sequences):
+    # Get the shape of the input_ids, which includes the padding.
+    maximum = max(sum(lengths) for lengths in sequences)
+    return (len(sequences), maximum)
+
+
+@pytest.fixture
+def seq_lengths(sequences):
+    return numpy.array([sum(seq) for seq in sequences], dtype="i")
+
+
+@pytest.fixture
+def align(sequences):
+    lengths = []
+    indices = []
+    offset = 0
+    for seq in sequences:
+        for token_length in seq:
+            lengths.append(token_length)
+            indices.extend(i+offset for i in range(token_length))
+            offset += token_length
+    return Ragged(numpy.array(indices, dtype="i"), numpy.array(lengths, dtype="i"))
+
+
+@pytest.fixture
+def max_length():
+    return 6
+
+
+@pytest.fixture
+def mask_from_end(shape, max_length):
+    n_seq, length = shape
+    bools = [
+        numpy.array([(i+1) < max_length for i in range(length)], dtype="bool")
+        for _ in range(n_seq)
+    ]
+    return numpy.concatenate(bools)
+
+
+def test_truncate_alignment_from_end(sequences, max_length, align, mask_from_end):
+    #print("Max length", max_length)
+    #print("Sequences", sequences)
+    #print("Mask", mask_from_end)
+    ops = NumpyOps()
+    truncated = _truncate_alignment(align, mask_from_end)
+    #print(truncated.dataXd.shape, truncated.lengths.sum())
+    #print("Before", list(map(list, ops.unflatten(align.dataXd, align.lengths))))
+    #print("After", list(map(list, ops.unflatten(truncated.dataXd, truncated.lengths))))
+    # Check that the number of tokens hasn't changed. We still need to have
+    # alignment for every token.
+    assert truncated.lengths.shape[0] == align.lengths.shape[0]
+    start = 0
+    for i, seq in enumerate(sequences):
+        end = start + len(seq)
+        # Get the alignment for this sequence of tokens. Each length in the
+        # alignment indicates the number of wordpiece tokens, so we need to
+        # check that the sum of the lengths doesn't exceed the maximum.
+        wp_indices = truncated[start:end]
+        assert wp_indices.lengths.sum() < max_length
+        # We're truncating from the end, so we shouldn't see different values
+        # except at the end of the sequence.
+        seen_zero = False
+        before = align[start:end]
+        for length_now, length_before in zip(wp_indices.lengths, before.lengths):
+            if seen_zero:
+                assert length_now == 0
+            elif length_now == 0:
+                seen_zero = True
+            else:
+                length_now == length_before

--- a/spacy_transformers/tests/test_truncation.py
+++ b/spacy_transformers/tests/test_truncation.py
@@ -40,7 +40,7 @@ def wordpieces(sequences):
         strings=strings,
         input_ids=numpy.zeros(shape, dtype="i"),
         token_type_ids=numpy.zeros(shape, dtype="i"),
-        attention_mask=numpy.zeros((shape[0], shape[1], shape[1]), dtype="f"),
+        attention_mask=numpy.zeros((shape[0], shape[1]), dtype="bool"),
         lengths=[len(seq) for seq in strings]
     )
     return wordpieces
@@ -82,7 +82,6 @@ def test_truncate_wordpieces(wordpieces, max_length, mask_from_end):
         assert truncated.input_ids[i].shape[0] <= max_length
         assert truncated.token_type_ids[i].shape[0] <= max_length
         assert truncated.attention_mask[i].shape[0] <= max_length
-        assert truncated.attention_mask[i].shape[1] <= max_length
 
 def test_truncate_alignment_from_end(sequences, max_length, align, mask_from_end):
     # print("Max length", max_length)
@@ -110,7 +109,7 @@ def test_truncate_alignment_from_end(sequences, max_length, align, mask_from_end
         before = align[start:end]
         for length_now, length_before in zip(wp_indices.lengths, before.lengths):
             if seen_zero:
-                assert length_now == 0
+                assert length_now == 0, wp_indices.lengths
             elif length_now == 0:
                 seen_zero = True
             else:

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -17,6 +17,7 @@ class DummyTokenizer:
         self.start_symbol = "<s>"
         self.end_symbol = "</s>"
         self.model_max_length = 512
+        self.pad_token = "[PAD]"
 
     @property
     def all_special_tokens(self):
@@ -110,7 +111,7 @@ def DummyTransformerModel(width: int, depth: int):
         width = model.attrs["width"]
         depth = model.attrs["depth"]
         tensors = []
-        shape = (tokens["input_ids"].shape[0], tokens["input_ids"].shape[1], width)
+        shape = (tokens.input_ids.shape[0], tokens.input_ids.shape[1], width)
         for i in range(depth):
             tensors.append(torch.zeros(*shape))
         return tensors, lambda d_tensors: tokens

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -130,7 +130,7 @@ def DummyTransformer(
             "get_spans": get_spans,
             "tokenizer": DummyTokenizer(),
             "grad_factor": 1.0,
-            "flush_cache_chance": 0.0
+            "flush_cache_chance": 0.0,
         },
         dims={"nO": width},
     )

--- a/spacy_transformers/truncate.py
+++ b/spacy_transformers/truncate.py
@@ -108,6 +108,6 @@ def _truncate_alignment(align: Ragged, mask: numpy.ndarray) -> Ragged:
     # Step 3: Calculate new align.lengths
     new_lengths = align.lengths.copy()
     for i in range(len(align.lengths)):
-        drops = mask[align[i].data.ravel()]
+        drops = ~mask[align[i].data.ravel()]
         new_lengths[i] -= drops.sum()
     return Ragged(new_align, new_lengths)

--- a/spacy_transformers/truncate.py
+++ b/spacy_transformers/truncate.py
@@ -1,11 +1,11 @@
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 import numpy
 from thinc.types import Ragged, Ints1d, Ints2d, Floats2d, Floats3d
 from .data_classes import WordpieceBatch
 
 
 def truncate_oversize_splits(
-    wordpieces: WordpieceBatch, align: Ragged, seq_lengths: Ints1d, max_length: int
+    wordpieces: WordpieceBatch, align: Ragged, max_length: int
 ) -> Tuple[WordpieceBatch, Ragged]:
     """Drop wordpieces from inputs that are too long. This can happen because 
     the splitter is based on linguistic tokens, and the number of wordpieces
@@ -49,14 +49,14 @@ def _get_truncation_mask_drop_from_end(
 
     Drop wordpieces from the end of the sequence.
     """
-    mask = numpy.ones(shape, dtype="b")
-    mask[max_length:] = 0
+    mask = numpy.ones(shape, dtype="bool")
+    mask[:, max_length:] = 0
     return mask
 
 
 def _truncate_tokens(wordpieces: WordpieceBatch, mask: numpy.ndarray) -> WordpieceBatch:
     n_seq = len(wordpieces)
-    mask1d = mask
+    mask1d = mask.ravel()
     mask = mask.reshape((n_seq, -1))
     n_wp = mask.size
     n_keep = mask.sum()
@@ -68,28 +68,18 @@ def _truncate_tokens(wordpieces: WordpieceBatch, mask: numpy.ndarray) -> Wordpie
             if mask[i, j]:
                 strings[-1].append(token)
 
-    def filter_ids(data: Ints2d) -> Ints2d:
+    def filter_array(data: Optional[Ints2d]) -> Optional[Ints2d]:
+        if data is None:
+            return None
         data1d = data.reshape((-1,))
         return data1d[mask1d].reshape((n_seq, -1))
 
-    def filter_attn(data: Floats3d) -> Floats3d:
-        # TODO: There must be a more elegant way to do this...
-        data2d = data.reshape((data.shape[0]*data.shape[1], data.shape[2]))
-        data2d = data2d[mask1d]
-        data3d = data2d.reshape((data.shape[0], -1, data.shape[2]))
-        mask2d = mask1d.reshape((data.shape[0], -1))
-        attn = []
-        for i in range(n_seq):
-            attn.append(data3d[i, :, mask2d[i]])
-        filtered = numpy.vstack(attn)
-        return filtered.reshape((n_seq, attn[-1].shape[0], attn[-1].shape[1]))
-
     return WordpieceBatch(
         strings=strings,
-        input_ids=filter_ids(wordpieces.input_ids),
-        token_type_ids=filter_ids(wordpieces.token_type_ids),
-        attention_mask=filter_attn(wordpieces.attention_mask),
+        input_ids=filter_array(wordpieces.input_ids),
+        attention_mask=filter_array(wordpieces.attention_mask),
         lengths=numpy.array([len(seq) for seq in strings], dtype="i"),
+        token_type_ids=filter_array(wordpieces.token_type_ids),
     )
 
 
@@ -108,17 +98,16 @@ def _truncate_alignment(align: Ragged, mask: numpy.ndarray) -> Ragged:
     # wordpieces doesn't matter, because we can filter it with the mask. So we
     # have [0, 0, 0, 1], i.e the wordpiece that was
     # at 0 is still at 0, and the wordpiece that was at 3 is now at 1.
+    mask = mask.ravel()
     idx_map = mask.cumsum() - 1
     idx_map[~mask] = -1
     # Step 1: Adjust all the indices in align.dataXd.
-    new_align = idx_map[align.dataXd]
+    new_align = idx_map[align.data.ravel()]
     # Step 2: Remove the dropped indices
-    dropped = new_align < 0
-    new_align = new_align[~dropped]
+    new_align = new_align[new_align >= 0]
     # Step 3: Calculate new align.lengths
     new_lengths = align.lengths.copy()
     for i in range(len(align.lengths)):
-        slice_ = align[i].data
-        drops = dropped[slice_]
+        drops = mask[align[i].data.ravel()]
         new_lengths[i] -= drops.sum()
     return Ragged(new_align, new_lengths)

--- a/spacy_transformers/truncate.py
+++ b/spacy_transformers/truncate.py
@@ -1,0 +1,101 @@
+from typing import Tuple
+import numpy
+from transformers import BatchEncoding
+from thinc.types import Ragged, Ints1d, Floats2d, Floats3d
+
+
+def truncate_oversize_splits(
+    token_data: BatchEncoding,
+    align: Ragged,
+    seq_lengths: Ints1d,
+    max_length: int
+) -> Tuple[BatchEncoding, Ragged]:
+    """Drop wordpieces from inputs that are too long. This can happen because 
+    the splitter is based on linguistic tokens, and the number of wordpieces
+    that each token is split into is unpredictable, so we can end up with splits
+    that have more wordpieces than the model's maximum.
+    
+    To solve this, we calculate a score for each wordpiece in the split,
+    and drop the wordpieces with the highest scores. I can think of a few
+    scoring schemes we could use:
+    
+    a) Drop the ends of longest wordpieces. This scoring would be just:
+        position_in_token 
+    b) Drop the middles of longest wordpieces. The score would be:
+        min(length - position_in_token, position_in_token)
+    c) Drop all wordpieces from longest tokens. This would be:
+        length
+    d) Drop wordpieces from the end of the split. This would be:
+        position_in_split
+    
+    The advantage of a) and b) is that they give some representation to each
+    token. The advantage of c) is that it leaves a higher % of tokens with intact
+    representations. The advantage of d) is that it leaves contiguous chunks of
+    wordpieces intact, and drops from the end.
+
+    I find b) most appealing, but it's also the most complicated. Let's just do
+    d) for now.
+    """
+    if token_data["input_ids"].shape[0] < max_length:
+        return token_data, align
+    mask = _get_truncation_mask_drop_from_end(seq_lengths, align, max_length)
+    return _truncate_tokens(token_data, mask), _truncate_align(align, mask)
+
+
+def _get_truncation_mask_drop_from_end(
+    split_lengths: Ints1d,
+    align: Ragged,
+    max_length: int
+) -> numpy.ndarray:
+    """Return a two-dimensional boolean mask, indicating whether wordpieces
+    are dropped from their sequences.
+
+    Drop wordpieces from the end of the sequence.
+    """
+    mask = xp.ones(token_data["input_ids"].shape, dtype="b")
+    mask[max_length:] = 0
+    return mask
+
+
+def _truncate_tokens(
+    token_data: BatchEncoding,
+    mask: numpy.ndarray
+) -> BatchEncoding:
+    # This is the part that will be annoying to do :(.
+    input_ids = token_data["input_ids"][mask]
+    # I don't know whether this works?
+    attention_mask = token_data["attention_mask"][mask, mask]
+    # TODO: Draw the rest of the owl.
+    ...
+    return BatchEncoding(...)
+
+
+def _truncate_alignment(align: Ragged, mask: numpy.ndarray) -> Ragged:
+    # We're going to have fewer wordpieces in the new array, so all of our
+    # wordpiece indices in the alignment table will be off --- they'll point
+    # to the wrong row. So we need to do three things here:
+    #
+    # 1) Adjust all the indices in align.dataXd to account for the dropped data
+    # 2) Remove the dropped indices from the align.dataXd
+    # 3) Calculate new align.lengths 
+    # 
+    # The wordpiece mapping is easily calculated by the cumulative sum of the
+    # mask table.
+    # Let's say we have [True, False, False, True]. The mapping of the dropped
+    # wordpieces doesn't matter, because we can filter it with the mask. So we
+    # have [0, 0, 0, 1], i.e the wordpiece that was
+    # at 0 is still at 0, and the wordpiece that was at 3 is now at 1. 
+    idx_map = mask.cumsum() - 1
+    idx_map[~mask] = -1
+    # Step 1: Adjust all the indices in align.dataXd.
+    new_align = idx_map[align.dataXd]
+    # Step 2: Remove the dropped indices
+    dropped = new_align < 0
+    new_align = new_align[~dropped]
+    # Step 3: Calculate new align.lengths
+    new_lengths = align.lengths.copy()
+    for i in range(len(align.lengths)):
+        slice_ = align[i].data
+        drops = dropped[slice_]
+        new_lengths[i] -= drops.sum()
+    return Ragged(new_align, new_lengths)


### PR DESCRIPTION
We need the wordpiece data to match against the original text, so we can't truncate before we align. After we align though, we can --- we just have to take care to adjust all the indices etc correctly. It's tricky and the code here is kind of heinous, but I'm sure this is the right path to take.

~There's very little chance this works right away on GPU, I've surely got at least one place where there's a numpy array that needs to be a cupy array, or vice versa.~ Nevermind, just tested on GPU and it seems to work!

I've also introduced a new data class, `WordpieceBatch`, to help manage the wordpieces data. I needed slicing, and I wanted to have typed attribute access instead of the janky dicts.

I've added a `.wordpieces` attribute to the `FullTransformerBatch` and `TransformerData` dataclasses, and added a deprecated `.tokens` property. The `.tokens` property returns dict data that matches the previous behaviour. This should make the change less breaking, because we have a new attribute with the new type, and a deprecated property that does the same thing as before.