### PR TITLE
update pytest pin to match Thinc 8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ importlib_metadata>=0.20; python_version < "3.8"
 spacy-alignments>=0.7.2,<1.0.0
 # Testing
 spacy-nightly>=3.0.0rc4,<3.1.0
-pytest>=5.0.1,<5.1.0
+pytest>=5.2.0
 pytest-cov>=2.7.0,<2.8.0


### PR DESCRIPTION
To ensure the `hypothesis` stuff in Thinc works properly