### PR TITLE
Add custom encoders/decoders to serialize dataclasses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 transformers>=3.1.0,<4.3.0
 torch>=1.5.0
 torchcontrib>=0.0.2,<0.1.0
-srsly>=2.0.1,<3.0.0
+srsly==2.4.0.dev0
 ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6; python_version < "3.7"
 importlib_metadata>=0.20; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 transformers>=3.1.0,<4.3.0
 torch>=1.5.0
 torchcontrib>=0.0.2,<0.1.0
-srsly==2.4.0.dev0
+srsly>=2.4.0,<3.0.0
 ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6; python_version < "3.7"
 importlib_metadata>=0.20; python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     transformers>=3.1.0,<4.3.0
     torch>=1.5.0
     torchcontrib>=0.0.2,<0.1.0
-    srsly==2.4.0.dev0
+    srsly>=2.4.0,<3.0.0
     ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6; python_version < "3.7"
     importlib_metadata>=0.20; python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     transformers>=3.1.0,<4.3.0
     torch>=1.5.0
     torchcontrib>=0.0.2,<0.1.0
-    srsly>=2.0.1,<3.0.0
+    srsly==2.4.0.dev0
     ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6; python_version < "3.7"
     importlib_metadata>=0.20; python_version < "3.8"

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -1,0 +1,9 @@
+from spacy_transformers import TransformerData
+import srsly
+
+
+def test_serialize_transformer_data():
+    data = {"x": TransformerData.empty()}
+    bytes_data = srsly.msgpack_dumps(data)
+    new_data = srsly.msgpack_loads(bytes_data)
+    assert isinstance(new_data["x"], TransformerData)


### PR DESCRIPTION
Use the msgpack function registry introduced in `srsly` v2.4.0 to support serializing `TransformerData` objects.