### PR TITLE
Refactor handling when doc._.trf_data is None

### DIFF
--- a/spacy_transformers/layers/listener.py
+++ b/spacy_transformers/layers/listener.py
@@ -58,13 +58,13 @@ def forward(model: TransformerListener, docs, is_train):
         model.verify_inputs(docs)
         return model._outputs, model.backprop_and_clear
     else:
-        if len(docs) == 0:
-            outputs = []
-        elif any(doc._.trf_data is None for doc in docs):
-            width = model.get_dim("nO")
-            outputs = [
-                TransformerData.zeros(len(doc), width, xp=model.ops.xp) for doc in docs
-            ]
-        else:
-            outputs = [doc._.trf_data for doc in docs]
+        width = model.get_dim("nO")
+        outputs = []
+        for doc in docs:
+            if doc._.trf_data is None:
+                outputs.append(
+                    TransformerData.zeros(len(doc), width, xp=model.ops.xp)
+                )
+            else:
+                outputs.append(doc._.trf_data)
         return outputs, lambda d_data: []


### PR DESCRIPTION
Re https://github.com/explosion/spaCy/issues/7029

I don't think this will be necessary because the same bug wouldn't occur, but it's probably good to make the implementations match.