### PR TITLE
Fix empty doc processing

### DIFF
--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -25,7 +25,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             t_i = find_last_hidden(trf_data.tensors)
             tensor_t_i = trf_data.tensors[t_i]
             if tensor_t_i.size == 0:
-                # account for empty doc in the batch
+                # account for empty trf_data in the batch
                 outputs.append(model.ops.alloc2f(0, 0))
             else:
                 src = model.ops.reshape2f(tensor_t_i, -1, trf_data.width)

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -23,11 +23,16 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
     for trf_data in trf_datas:
         if len(trf_data.tensors) > 0:
             t_i = find_last_hidden(trf_data.tensors)
-            src = model.ops.reshape2f(trf_data.tensors[t_i], -1, trf_data.width)
-            dst, get_d_src = apply_alignment(model.ops, trf_data.align, src)
-            output, get_d_dst = pooling(dst, is_train)
-            outputs.append(output)
-            backprops.append((get_d_dst, get_d_src))
+            tensor_t_i = trf_data.tensors[t_i]
+            if tensor_t_i.size == 0:
+                # account for empty doc in the batch
+                outputs.append(model.ops.alloc2f(0, 0))
+            else:
+                src = model.ops.reshape2f(tensor_t_i, -1, trf_data.width)
+                dst, get_d_src = apply_alignment(model.ops, trf_data.align, src)
+                output, get_d_dst = pooling(dst, is_train)
+                outputs.append(output)
+                backprops.append((get_d_dst, get_d_src))
         else:
             outputs.append(model.ops.alloc2f(0, 0))
 

--- a/spacy_transformers/tests/regression/test_spacy_issue7029.py
+++ b/spacy_transformers/tests/regression/test_spacy_issue7029.py
@@ -1,0 +1,51 @@
+from spacy.lang.en import English
+from spacy.training import Example
+from spacy.util import load_config_from_str
+
+CONFIG = """
+[nlp]
+lang = "en"
+pipeline = ["transformer", "tagger"]
+
+[components]
+
+[components.transformer]
+factory = "transformer"
+
+[components.tagger]
+factory = "tagger"
+
+[components.tagger.model]
+@architectures = "spacy.Tagger.v1"
+nO = null
+
+[components.tagger.model.tok2vec]
+@architectures = "spacy-transformers.TransformerListener.v1"
+grad_factor = 1.0
+
+[components.tagger.model.tok2vec.pooling]
+@layers = "reduce_mean.v1"
+"""
+
+
+TRAIN_DATA = [
+    ("I like green eggs", {"tags": ["N", "V", "J", "N"]}),
+    ("Eat blue ham", {"tags": ["V", "J", "N"]}),
+]
+
+
+def test_issue7029():
+    """Test that an empty document doesn't mess up an entire batch.
+    """
+    nlp = English.from_config(load_config_from_str(CONFIG))
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    optimizer = nlp.initialize(get_examples=lambda: train_examples)
+    for i in range(2):
+        losses = {}
+        nlp.update(train_examples, sgd=optimizer, losses=losses)
+    texts = ["first", "second", "third", "fourth", "and", "then", "some", ""]
+    docs1 = list(nlp.pipe(texts, batch_size=1))
+    docs2 = list(nlp.pipe(texts, batch_size=4))
+    assert [doc[0].tag_ for doc in docs1[:-1]] == [doc[0].tag_ for doc in docs2[:-1]]

--- a/spacy_transformers/tests/regression/test_spacy_issue7029.py
+++ b/spacy_transformers/tests/regression/test_spacy_issue7029.py
@@ -34,8 +34,8 @@ TRAIN_DATA = [
 ]
 
 
-def test_issue7029():
-    """Test that an empty document doesn't mess up an entire batch.
+def test_empty_doc():
+    """Test that an empty document gets processed correctly
     """
     nlp = English.from_config(load_config_from_str(CONFIG))
     train_examples = []
@@ -46,6 +46,15 @@ def test_issue7029():
         losses = {}
         nlp.update(train_examples, sgd=optimizer, losses=losses)
     texts = ["first", "second", "third", "fourth", "and", "then", "some", ""]
+
+    # run as normal
+    nlp.select_pipes(enable=["transformer", "tagger"])
+    docs1 = list(nlp.pipe(texts, batch_size=1))
+    docs2 = list(nlp.pipe(texts, batch_size=4))
+    assert [doc[0].tag_ for doc in docs1[:-1]] == [doc[0].tag_ for doc in docs2[:-1]]
+
+    # disable the transformer (the listener will produce random output)
+    nlp.select_pipes(enable=["tagger"])
     docs1 = list(nlp.pipe(texts, batch_size=1))
     docs2 = list(nlp.pipe(texts, batch_size=4))
     assert [doc[0].tag_ for doc in docs1[:-1]] == [doc[0].tag_ for doc in docs2[:-1]]


### PR DESCRIPTION
While I was writing a test case for PR https://github.com/explosion/spacy-transformers/pull/264, I ended up stumbling on another bug/quirck. If the transformer is disabled, the pipeline still runs because the listener produces random arrays (...), but this doesn't work when the doc is empty. Added an additional check in `trfs2arrays` for this case.