### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
 spacy>=3.0.0,<3.1.0
 transformers>=3.4.0,<4.6.0
 torch>=1.5.0
-torchcontrib>=0.0.2,<0.1.0
 srsly>=2.4.0,<3.0.0
-ftfy>=5.0.0,<6.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"
-importlib_metadata>=0.20; python_version < "3.8"
 spacy-alignments>=0.7.2,<1.0.0
 # Testing
 pytest>=5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,13 +27,11 @@ zip_safe = false
 include_package_data = true
 python_requires = >=3.6
 install_requires =
+    spacy>=3.0.0,<3.1.0
     transformers>=3.4.0,<4.6.0
     torch>=1.5.0
-    torchcontrib>=0.0.2,<0.1.0
     srsly>=2.4.0,<3.0.0
-    ftfy>=5.0.0,<6.0.0
     dataclasses>=0.6,<1.0; python_version < "3.7"
-    importlib_metadata>=0.20; python_version < "3.8"
     spacy-alignments>=0.7.2,<1.0.0
 
 setup_requires =


### PR DESCRIPTION
* Add `spacy` back as an install requirement (downgrading `spacy` in an env wouldn't downgrade `spacy-transformers`, leading to a broken env)
* Remove unused: `torchcontrib`, `ftfy`, `importlib-metadata`