### PR TITLE
Fixing Transformer IO

### DIFF
--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -5,15 +5,13 @@ from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
 from spacy.training import Example, validate_examples, validate_get_examples
-from spacy import util
+from spacy import util, Errors
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer
 import srsly
-import torch
-from transformers import WEIGHTS_NAME, CONFIG_NAME
 from pathlib import Path
 
-from .util import huggingface_from_pretrained, batch_by_length
+from .util import batch_by_length
 from .annotation_setters import null_annotation_setter
 from .data_classes import FullTransformerBatch, TransformerData
 from .layers import TransformerListener
@@ -335,7 +333,10 @@ class Transformer(TrainablePipe):
         pass
 
     def initialize(
-        self, get_examples: Callable[[], Iterable[Example]], *, nlp: Optional[Language] = None
+        self,
+        get_examples: Callable[[], Iterable[Example]],
+        *,
+        nlp: Optional[Language] = None,
     ):
         """Initialize the pipe for training, using data examples if available.
 
@@ -365,20 +366,10 @@ class Transformer(TrainablePipe):
 
         DOCS: https://spacy.io/api/transformer#to_disk
         """
-
-        def save_model(p):
-            trf_dir = Path(p).absolute()
-            if not trf_dir.exists():
-                trf_dir.mkdir()
-            self.model.attrs["tokenizer"].save_pretrained(str(trf_dir))
-            transformer = self.model.layers[0].shims[0]._model
-            torch.save(transformer.state_dict(), trf_dir / WEIGHTS_NAME)
-            transformer.config.to_json_file(trf_dir / CONFIG_NAME)
-
         serialize = {}
         serialize["cfg"] = lambda p: srsly.write_json(p, self.cfg)
         serialize["vocab"] = lambda p: self.vocab.to_disk(p)
-        serialize["model"] = lambda p: save_model(p)
+        serialize["model"] = lambda p: self.model.to_disk(p)
         util.to_disk(path, serialize, exclude)
 
     def from_disk(
@@ -394,12 +385,11 @@ class Transformer(TrainablePipe):
         """
 
         def load_model(p):
-            p = Path(p).absolute()
-            tokenizer, transformer = huggingface_from_pretrained(
-                p, self.model.attrs["tokenizer_config"], self.model.attrs["transformer_config"]
-            )
-            self.model.attrs["tokenizer"] = tokenizer
-            self.model.attrs["set_transformer"](self.model, transformer)
+            try:
+                with open(p, "rb") as mfile:
+                    self.model.from_bytes(mfile.read())
+            except AttributeError:
+                raise ValueError(Errors.E149) from None
 
         deserialize = {
             "vocab": self.vocab.from_disk,

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -185,7 +185,6 @@ def test_transformer_pipeline_tagger_listener():
     # ensure to_bytes / from_bytes works
     nlp_bytes = nlp.to_bytes()
     nlp3 = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
-    nlp3.initialize(lambda: train_examples)
     nlp3.from_bytes(nlp_bytes)
     doc = nlp3(text)
     tagger3 = nlp3.get_pipe("tagger")

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -1,4 +1,5 @@
 from spacy import Language
+from spacy.util import make_tempdir
 
 from spacy_transformers import TransformerData
 import srsly
@@ -29,8 +30,18 @@ def test_transformer_model_tobytes():
 
     nlp2 = Language()
     trf2 = nlp2.add_pipe("transformer")
-    # nlp2.initialize()
     trf2.from_bytes(trf_bytes)
+
+
+def test_transformer_model_todisk():
+    nlp = Language()
+    trf = nlp.add_pipe("transformer")
+    nlp.initialize()
+    with make_tempdir() as d:
+        trf.to_disk(d)
+        nlp2 = Language()
+        trf2 = nlp2.add_pipe("transformer")
+        trf2.from_disk(d)
 
 
 def test_transformer_pipeline_tobytes():
@@ -44,3 +55,13 @@ def test_transformer_pipeline_tobytes():
     nlp2.add_pipe("transformer")
     nlp2.from_bytes(nlp_bytes)
     assert nlp2.pipe_names == ["transformer"]
+
+
+def test_transformer_pipeline_todisk():
+    nlp = Language()
+    nlp.add_pipe("transformer")
+    nlp.initialize()
+    with make_tempdir() as d:
+        nlp.to_disk(d)
+        nlp2 = Language()
+        nlp2.from_disk(d)

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -29,5 +29,18 @@ def test_transformer_model_tobytes():
 
     nlp2 = Language()
     trf2 = nlp2.add_pipe("transformer")
-    nlp2.initialize()
+    # nlp2.initialize()
     trf2.from_bytes(trf_bytes)
+
+
+def test_transformer_pipeline_tobytes():
+    nlp = Language()
+    nlp.add_pipe("transformer")
+    nlp.initialize()
+    assert nlp.pipe_names == ["transformer"]
+    nlp_bytes = nlp.to_bytes()
+
+    nlp2 = Language()
+    nlp2.add_pipe("transformer")
+    nlp2.from_bytes(nlp_bytes)
+    assert nlp2.pipe_names == ["transformer"]

--- a/spacy_transformers/tests/test_tok2vectransformer.py
+++ b/spacy_transformers/tests/test_tok2vectransformer.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from spacy.training.example import Example
 from spacy.util import make_tempdir
@@ -68,10 +70,10 @@ def test_transformer_pipeline_tagger_internal():
     with make_tempdir() as d:
         file_path = d / "trained_nlp"
         nlp.to_disk(file_path)
-        nlp2 = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
-        nlp2.initialize(lambda: train_examples)
 
         # results are not the same if we don't call from_disk
+        nlp2 = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
+        nlp2.initialize(lambda: train_examples)
         doc2 = nlp2("We're interested at underwater basket weaving.")
         tagger2 = nlp2.get_pipe("tagger")
         tagger_trf2 = tagger2.model.get_ref("tok2vec").layers[0]
@@ -80,9 +82,11 @@ def test_transformer_pipeline_tagger_internal():
             assert_equal(doc_tensor2.doc_data[0].tensors, doc_tensor.doc_data[0].tensors)
 
         # results ARE the same if we call from_disk
-        nlp2.from_disk(file_path)
-        doc2 = nlp2("We're interested at underwater basket weaving.")
-        tagger2 = nlp2.get_pipe("tagger")
-        tagger_trf2 = tagger2.model.get_ref("tok2vec").layers[0]
-        doc_tensor2 = tagger_trf2.predict([doc2])
-        assert_equal(doc_tensor2.doc_data[0].tensors, doc_tensor.doc_data[0].tensors)
+        nlp3 = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
+        # nlp3.initialize(lambda: train_examples)
+        nlp3.from_disk(file_path)
+        doc3 = nlp3("We're interested at underwater basket weaving.")
+        tagger3 = nlp3.get_pipe("tagger")
+        tagger_trf3 = tagger3.model.get_ref("tok2vec").layers[0]
+        doc_tensor3 = tagger_trf3.predict([doc3])
+        assert_equal(doc_tensor3.doc_data[0].tensors, doc_tensor.doc_data[0].tensors)

--- a/spacy_transformers/tests/test_tok2vectransformer.py
+++ b/spacy_transformers/tests/test_tok2vectransformer.py
@@ -83,7 +83,6 @@ def test_transformer_pipeline_tagger_internal():
 
         # results ARE the same if we call from_disk
         nlp3 = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
-        # nlp3.initialize(lambda: train_examples)
         nlp3.from_disk(file_path)
         doc3 = nlp3("We're interested at underwater basket weaving.")
         tagger3 = nlp3.get_pipe("tagger")


### PR DESCRIPTION
Note: some tests are adjusted in this PR. This was done first, before implementing the code changes, as we were aware that the `initialize` statements shouldn't be there, cf https://github.com/explosion/spaCy/issues/8319 and https://github.com/explosion/spaCy/issues/8566. 

## Description

Before this PR, the HF Transformer model was loaded through `set_pytorch_transformer` (stored in `model.attrs["set_transformer"]`), but this happened in the `initialize` call of `TransformerModel`. Unfortunately, this meant that saving/loading a transformer-based pipeline was kind of broken, as you needed to call `initialize` on a previously trained pipeline, which isn't the normal spaCy API. This also broke the `from_bytes` / `to_bytes` typical API.

Furthermore, the `from_disk` / `to_disk` functionality worked with a "listener" transformer, because the `transformer` pipeline component saved out the PyTorch files directly. However, this solution did not work for the "inline" Transformer, because the `TransformerModel` would be used directly and not via the pipeline component.

I've been looking at various different solutions, but the proposal in this PR is the only one that I got working for all use-cases: basically we need to load/define the transformer model in the constructor as we do for any other spaCy component.

Unfortunately with this proposal, if you'd have the `initialize` calls as before in your old code, it will crash, complaining about the fact that the transformer model can't be set twice. I think this is actually the correct behaviour in the end, but it might break some people's code. The fix is obvious/easy though. 

But we'll have to discuss which version bump we want to do when releasing this.

Fixes https://github.com/explosion/spaCy/issues/8319
Fixes https://github.com/explosion/spaCy/issues/8566