### PR TITLE
Use ModelOutput instead of tuples

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,12 @@ jobs:
       Python37Mac:
         imageName: 'macos-10.14'
         python.version: '3.7'
-      Python38Linux:
-        imageName: 'ubuntu-18.04'
-        python.version: '3.8'
       Python38Mac:
         imageName: 'macos-10.14'
         python.version: '3.8'
+      Python39Linux:
+        imageName: 'ubuntu-18.04'
+        python.version: '3.9'
     maxParallel: 4
   pool:
     vmImage: $(imageName)

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -327,7 +327,7 @@ class FullTransformerBatch:
                 elif (
                     isinstance(output, tuple)
                     and all(isinstance(t, torch.Tensor) for t in output)
-                    and all(t.shape[-2] == last_hidden_state.shape[-2] for t in output)
+                    and all(t.shape[0] == last_hidden_state.shape[0] for t in output)
                 ):
                     model_output[key] = [torch2xp(t[start:end]) for t in output]
             outputs.append(

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -174,8 +174,8 @@ class TransformerData:
         )
 
     @property
-    def tensors(self) -> List[Union[FloatsXd, List[FloatsXd]]]:
-        return list(self.model_output.to_tuple())
+    def tensors(self) -> Tuple[Union[FloatsXd, List[FloatsXd]]]:
+        return self.model_output.to_tuple()
 
     @property
     def tokens(self) -> Dict[str, Any]:
@@ -268,8 +268,8 @@ class FullTransformerBatch:
         )
 
     @property
-    def tensors(self) -> List[Union[torch.Tensor, Tuple[torch.Tensor]]]:
-        return list(self.model_output.to_tuple())
+    def tensors(self) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor]]]:
+        return self.model_output.to_tuple()
 
     @property
     def tokens(self) -> Dict[str, Any]:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -190,12 +190,14 @@ class TransformerData:
             "wordpieces": self.wordpieces.to_dict(),
             "tensors": self.tensors,
             "align": [self.align.dataXd, self.align.lengths],
+            "model_output": self.model_output,
         }
 
     def from_dict(self, msg: Dict[str, Any]) -> "TransformerData":
         self.wordpieces = WordpieceBatch.empty().from_dict(msg["wordpieces"])
         self.tensors = msg["tensors"]
         self.align = Ragged(*msg["align"])
+        self.model_output = msg["model_output"]
         return self
 
     def to_bytes(self) -> bytes:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -262,7 +262,7 @@ class FullTransformerBatch:
         return cls(
             spans=spans,
             wordpieces=WordpieceBatch.empty(),
-            tensors=BaseModelOutput(),
+            tensors=BaseModelOutput(last_hidden_state=[]),
             align=align,
             attentions=None,
             cached_doc_data=doc_data,

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, List, Dict, Any, Union, Tuple
 import torch
 import numpy
 from transformers.tokenization_utils import BatchEncoding
 from transformers.file_utils import ModelOutput
-from thinc.types import Ragged, Floats3d, Ints2d
+from thinc.types import Ragged, Floats3d, FloatsXd, Ints2d
 from thinc.api import get_array_module, xp2torch, torch2xp
 from spacy.tokens import Span
 import srsly
@@ -174,8 +174,8 @@ class TransformerData:
         )
 
     @property
-    def tensors(self) -> Tuple:
-        return self.model_output.to_tuple()
+    def tensors(self) -> List[Union[FloatsXd, List[FloatsXd]]]:
+        return list(self.model_output.to_tuple())
 
     @property
     def tokens(self) -> Dict[str, Any]:
@@ -268,8 +268,8 @@ class FullTransformerBatch:
         )
 
     @property
-    def tensors(self) -> Tuple:
-        return self.model_output.to_tuple()
+    def tensors(self) -> List[Union[torch.Tensor, Tuple[torch.Tensor]]]:
+        return list(self.model_output.to_tuple())
 
     @property
     def tokens(self) -> Dict[str, Any]:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -135,24 +135,21 @@ class TransformerData:
     The transformer models return tensors that refer to a whole padded batch
     of documents. These tensors are wrapped into the FullTransformerBatch object.
     The FullTransformerBatch then splits out the per-document data, which is
-    handled by this class. Instances of this class are` typically assigned to
+    handled by this class. Instances of this class are typically assigned to
     the doc._.trf_data extension attribute.
 
     Attributes
     ----------
     wordpieces (WordpieceBatch): A slice of the wordpiece token data produced
         by the Huggingface tokenizer.
-    tensors (List[FloatsXd]): The activations for the Doc from the transformer.
-        Usually the last tensor that is 3-dimensional will be the most important,
-        as that will provide the final hidden state. Generally activations that
-        are 2-dimensional will be attention weights. Details of this variable
-        will differ depending on the underlying transformer model.
+    tensors (List[FloatsXd]): A list containing as the first element the last
+        hidden state for the doc from the transformer.
     align (Ragged): Alignment from the Doc's tokenization to the wordpieces.
         This is a ragged array, where align.lengths[i] indicates the number of
         wordpiece tokens that token i aligns against. The actual indices are
         provided at align[i].dataXd.
     model_output (Optional[ModelOutput]): Any additional model output from the
-        transformer model.
+        transformer model, determined by the model and transformer config.
     """
 
     wordpieces: WordpieceBatch

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -260,7 +260,7 @@ class FullTransformerBatch:
         return cls(
             spans=spans,
             wordpieces=WordpieceBatch.empty(),
-            tensors=ModelOutput(last_hidden_state=torch.FloatTensor((0,))),
+            tensors=ModelOutput(),
             align=align,
             cached_doc_data=doc_data,
         )

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -19,8 +19,8 @@ class HFObjects:
 
     tokenizer: Any
     transformer: Any
-    init_tokenizer_config: Dict[str, Any] = field(default_factory=dict)
-    init_transformer_config: Dict[str, Any] = field(default_factory=dict)
+    _init_tokenizer_config: Dict[str, Any] = field(default_factory=dict)
+    _init_transformer_config: Dict[str, Any] = field(default_factory=dict)
 
 
 class HFShim(PyTorchShim):

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -40,7 +40,7 @@ class HFShim(PyTorchShim):
             config = hf_model.transformer.config.to_dict()
             tokenizer = hf_model.tokenizer
             with make_tempdir() as temp_dir:
-                tokenizer.save_pretrained(temp_dir)
+                tokenizer.save_pretrained(str(temp_dir.absolute()))
                 for x in temp_dir.glob("**/*"):
                     if x.is_file():
                         tok_dict[x.name] = x.read_bytes()

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 from io import BytesIO
 from pathlib import Path
 import srsly
-from functools import partial
 import torch
 from dataclasses import dataclass, field
 from spacy.vectors import get_current_ops
@@ -75,7 +74,6 @@ class HFShim(PyTorchShim):
                 )
 
             transformer = AutoModel.from_config(config)
-            transformer.forward = partial(transformer.forward, **trf_config)
             self._hfmodel = HFObjects(transformer, tokenizer, tok_config, trf_config)
             self._model = transformer
             filelike = BytesIO(msg["state"])

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -17,8 +17,8 @@ from transformers import AutoModel, AutoConfig, AutoTokenizer
 @dataclass
 class HFObjects:
 
-    transformer: Any
     tokenizer: Any
+    transformer: Any
     init_tokenizer_config: Dict[str, Any] = field(default_factory=dict)
     init_transformer_config: Dict[str, Any] = field(default_factory=dict)
 
@@ -70,7 +70,7 @@ class HFShim(PyTorchShim):
 
             transformer = AutoModel.from_config(config)
             self._hfmodel = HFObjects(
-                transformer, tokenizer, SimpleFrozenDict(), SimpleFrozenDict()
+                tokenizer, transformer, SimpleFrozenDict(), SimpleFrozenDict()
             )
             self._model = transformer
             filelike = BytesIO(msg["state"])

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -1,5 +1,5 @@
 from typing import List, Tuple, Callable
-from transformers.modeling_outputs import BaseModelOutput
+from transformers.file_utils import ModelOutput
 
 from spacy_transformers.layers._util import replace_listener, replace_listener_cfg
 from thinc.types import ArgsKwargs
@@ -164,7 +164,7 @@ def forward(
     def backprop_transformer(d_output: FullTransformerBatch) -> List[Doc]:
         if "logger" in model.attrs:
             log_gpu_memory(model.attrs["logger"], "Begin backprop")
-        _ = bp_tensors(d_output.tensors.last_hidden_state)
+        _ = bp_tensors(d_output.tensors.values())
         if "logger" in model.attrs:
             log_gpu_memory(model.attrs["logger"], "After backprop")
         return docs
@@ -186,7 +186,7 @@ def _convert_transformer_inputs(model, wps: WordpieceBatch, is_train):
 def _convert_transformer_outputs(model, inputs_outputs, is_train):
     _, tensors = inputs_outputs
 
-    def backprop(d_tensors: BaseModelOutput) -> ArgsKwargs:
-        return ArgsKwargs(args=(tensors.values(),), kwargs={"grad_tensors": d_tensors})
+    def backprop(d_tensors: ModelOutput) -> ArgsKwargs:
+        return ArgsKwargs(args=(tensors.last_hidden_state,), kwargs={"grad_tensors": d_tensors})
 
     return tensors, backprop

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -71,12 +71,12 @@ class TransformerModel(Model):
         return self.layers[0].shims[0]._hfmodel.transformer
 
     @property
-    def init_tokenizer_config(self):
-        return self.layers[0].shims[0]._hfmodel.init_tokenizer_config
+    def _init_tokenizer_config(self):
+        return self.layers[0].shims[0]._hfmodel._init_tokenizer_config
 
     @property
-    def init_transformer_config(self):
-        return self.layers[0].shims[0]._hfmodel.init_transformer_config
+    def _init_transformer_config(self):
+        return self.layers[0].shims[0]._hfmodel._init_transformer_config
 
     def copy(self):
         """
@@ -121,8 +121,8 @@ def init(model: Model, X=None, Y=None):
     if model.attrs["has_transformer"]:
         return
     name = model.attrs["name"]
-    tok_cfg = model.init_tokenizer_config
-    trf_cfg = model.init_transformer_config
+    tok_cfg = model._init_tokenizer_config
+    trf_cfg = model._init_transformer_config
     tokenizer, transformer = huggingface_from_pretrained(name, tok_cfg, trf_cfg)
     model.attrs["set_transformer"](model, transformer, tokenizer)
     tokenizer = model.tokenizer

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -147,16 +147,11 @@ def forward(
     tensors, bp_tensors = transformer(wordpieces, is_train)
     if "logger" in model.attrs:
         log_gpu_memory(model.attrs["logger"], "after forward")
-    if "output_attentions" in trf_cfg and trf_cfg["output_attentions"] is True:
-        attn = tensors.attentions
-    else:
-        attn = None
     output = FullTransformerBatch(
         spans=nested_spans,
         wordpieces=wordpieces,
         tensors=tensors,
         align=align,
-        attentions=attn,
     )
     if "logger" in model.attrs:
         log_gpu_memory(model.attrs["logger"], "return from forward")

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -71,12 +71,12 @@ class TransformerModel(Model):
         return self.layers[0].shims[0]._hfmodel.transformer
 
     @property
-    def tokenizer_config(self):
-        return self.layers[0].shims[0]._hfmodel.tokenizer_config
+    def init_tokenizer_config(self):
+        return self.layers[0].shims[0]._hfmodel.init_tokenizer_config
 
     @property
-    def transformer_config(self):
-        return self.layers[0].shims[0]._hfmodel.transformer_config
+    def init_transformer_config(self):
+        return self.layers[0].shims[0]._hfmodel.init_transformer_config
 
     def copy(self):
         """
@@ -121,8 +121,8 @@ def init(model: Model, X=None, Y=None):
     if model.attrs["has_transformer"]:
         return
     name = model.attrs["name"]
-    tok_cfg = model.tokenizer_config
-    trf_cfg = model.transformer_config
+    tok_cfg = model.init_tokenizer_config
+    trf_cfg = model.init_transformer_config
     tokenizer, transformer = huggingface_from_pretrained(name, tok_cfg, trf_cfg)
     model.attrs["set_transformer"](model, transformer, tokenizer)
     tokenizer = model.tokenizer

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -2,7 +2,6 @@ from typing import List
 from thinc.api import Model
 from thinc.types import Ragged, Floats2d, FloatsXd
 from ..data_classes import TransformerData
-from ..util import find_last_hidden
 from ..align import apply_alignment
 
 
@@ -22,8 +21,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
     backprops = []
     for trf_data in trf_datas:
         if len(trf_data.tensors) > 0:
-            t_i = find_last_hidden(trf_data.tensors)
-            tensor_t_i = trf_data.tensors[t_i]
+            tensor_t_i = trf_data.tensors[0]
             if tensor_t_i.size == 0:
                 # account for empty trf_data in the batch
                 outputs.append(model.ops.alloc2f(0, 0))
@@ -46,8 +44,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             d_dst = get_d_dst(d_output)
             d_src = get_d_src(d_dst)
             d_src *= grad_factor
-            t_i = find_last_hidden(trf_data.tensors)
-            d_tensors[t_i] = d_src.reshape(trf_data.tensors[t_i].shape)
+            d_tensors[0] = d_src.reshape(trf_data.tensors[0].shape)
             d_trf_datas.append(
                 TransformerData(
                     tensors=d_tensors,

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -305,7 +305,7 @@ class Transformer(TrainablePipe):
                     # type: ignore
                     losses[self.name] += float((d_tensor ** 2).sum())
                 if i >= len(d_tensors):
-                    d_tensors.append(list(d_trf_data.tensors))
+                    d_tensors.append(d_trf_data.tensors)
                 else:
                     for j, d_tensor in enumerate(d_trf_data.tensors):
                         d_tensors[i][j] += d_tensor

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -335,7 +335,10 @@ class Transformer(TrainablePipe):
         pass
 
     def initialize(
-        self, get_examples: Callable[[], Iterable[Example]], *, nlp: Optional[Language] = None
+        self,
+        get_examples: Callable[[], Iterable[Example]],
+        *,
+        nlp: Optional[Language] = None,
     ):
         """Initialize the pipe for training, using data examples if available.
 
@@ -396,7 +399,9 @@ class Transformer(TrainablePipe):
         def load_model(p):
             p = Path(p).absolute()
             tokenizer, transformer = huggingface_from_pretrained(
-                p, self.model.attrs["tokenizer_config"], self.model.attrs["transformer_config"]
+                p,
+                self.model.attrs["tokenizer_config"],
+                self.model.attrs["transformer_config"],
             )
             self.model.attrs["tokenizer"] = tokenizer
             self.model.attrs["set_transformer"](self.model, transformer)

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -305,7 +305,7 @@ class Transformer(TrainablePipe):
                     # type: ignore
                     losses[self.name] += float((d_tensor ** 2).sum())
                 if i >= len(d_tensors):
-                    d_tensors.append(d_trf_data.tensors)
+                    d_tensors.append(list(d_trf_data.tensors))
                 else:
                     for j, d_tensor in enumerate(d_trf_data.tensors):
                         d_tensors[i][j] += d_tensor

--- a/spacy_transformers/tests/test_configs.py
+++ b/spacy_transformers/tests/test_configs.py
@@ -55,7 +55,6 @@ cfg_string = """
 
 @pytest.mark.parametrize("config_string", [cfg_string])
 def test_init_nlp(config_string):
-
     @spacy.registry.readers.register("toy_tagger_data.v1")
     def read_tagger_data():
         def parse_data(nlp, index):
@@ -68,8 +67,6 @@ def test_init_nlp(config_string):
         }
 
     config = spacy.util.load_config_from_str(config_string, interpolate=False)
-    config = Config(
-        DEFAULT_CONFIG, section_order=CONFIG_SECTION_ORDER
-    ).merge(config)
+    config = Config(DEFAULT_CONFIG, section_order=CONFIG_SECTION_ORDER).merge(config)
     nlp = init_nlp(config, use_gpu=False)
     assert nlp is not None

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -6,8 +6,7 @@ from ..data_classes import FullTransformerBatch
 from ..span_getters import get_doc_spans
 
 
-MODEL_NAMES = ["distilbert-base-uncased"]
-# "bert-base-uncased", "gpt2", "xlnet-base-cased"]
+MODEL_NAMES = ["distilbert-base-uncased", "gpt2", "xlnet-base-cased"]
 
 
 @pytest.fixture
@@ -28,9 +27,17 @@ def name(request):
 
 @pytest.fixture(scope="session")
 def trf_model(name):
-    model = TransformerModel(
-        name, get_doc_spans, {"use_fast": True}, {"output_attentions": False}
-    )
+    if name == "gpt2":
+        model = TransformerModel(
+            name,
+            get_doc_spans,
+            {"use_fast": True, "pad_token": "<|endoftext|>"},
+            {"output_attentions": False},
+        )
+    else:
+        model = TransformerModel(
+            name, get_doc_spans, {"use_fast": True}, {"output_attentions": False}
+        )
     model.initialize()
     return model
 

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -20,17 +20,17 @@ def docs(nlp):
     return [nlp(text) for text in texts]
 
 
-@pytest.fixture(scope="session", params=MODEL_NAMES)
+@pytest.fixture(scope="module", params=MODEL_NAMES)
 def name(request):
     return request.param
 
 
-@pytest.fixture(scope="session", params=[True, False])
+@pytest.fixture(scope="module", params=[True, False])
 def output_attentions(request):
     return request.param
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def trf_model(name, output_attentions):
     if name == "gpt2":
         model = TransformerModel(

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -67,15 +67,15 @@ def test_model_init(name, trf_model):
 
 def test_model_predict(docs, trf_model):
     outputs = trf_model.predict(docs)
-    shape = outputs.tensors.last_hidden_state.shape
+    shape = outputs.model_output.last_hidden_state.shape
     if trf_model.attrs["transformer_config"].get("output_attentions", None) is True:
-        assert outputs.tensors.attentions is not None
-        assert all([t.shape[0] == shape[0] for t in outputs.tensors.attentions])
+        assert outputs.model_output.attentions is not None
+        assert all([t.shape[0] == shape[0] for t in outputs.model_output.attentions])
     else:
-        assert outputs.tensors.attentions is None
+        assert outputs.model_output.attentions is None
     if trf_model.attrs["transformer_config"].get("output_hidden_states", None) is True:
-        assert outputs.tensors.hidden_states is not None
-        assert all([t.shape[0] == shape[0] for t in outputs.tensors.hidden_states])
+        assert outputs.model_output.hidden_states is not None
+        assert all([t.shape[0] == shape[0] for t in outputs.model_output.hidden_states])
     else:
-        assert outputs.tensors.hidden_states is None
+        assert outputs.model_output.hidden_states is None
     assert isinstance(outputs, FullTransformerBatch)

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -57,7 +57,7 @@ def test_model_init(name, trf_model):
 def test_model_predict(docs, trf_model):
     outputs = trf_model.predict(docs)
     if trf_model.attrs["transformer_config"].get("output_attentions", None) is True:
-        assert outputs.attentions is not None
+        assert outputs.tensors.attentions is not None
     else:
-        assert outputs.attentions is None
+        assert outputs.tensors.attentions is None
     assert isinstance(outputs, FullTransformerBatch)

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -70,12 +70,12 @@ def test_model_predict(docs, trf_model):
     shape = outputs.tensors.last_hidden_state.shape
     if trf_model.attrs["transformer_config"].get("output_attentions", None) is True:
         assert outputs.tensors.attentions is not None
-        assert all([t.shape[-2] == shape[-2] for t in outputs.tensors.attentions])
+        assert all([t.shape[0] == shape[0] for t in outputs.tensors.attentions])
     else:
         assert outputs.tensors.attentions is None
     if trf_model.attrs["transformer_config"].get("output_hidden_states", None) is True:
         assert outputs.tensors.hidden_states is not None
-        assert all([t.shape[-2] == shape[-2] for t in outputs.tensors.hidden_states])
+        assert all([t.shape[0] == shape[0] for t in outputs.tensors.hidden_states])
     else:
         assert outputs.tensors.hidden_states is None
     assert isinstance(outputs, FullTransformerBatch)

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -68,12 +68,12 @@ def test_model_init(name, trf_model):
 def test_model_predict(docs, trf_model):
     outputs = trf_model.predict(docs)
     shape = outputs.model_output.last_hidden_state.shape
-    if trf_model.transformer_config.get("output_attentions", None) is True:
+    if trf_model.transformer.config.output_attentions is True:
         assert outputs.model_output.attentions is not None
         assert all([t.shape[0] == shape[0] for t in outputs.model_output.attentions])
     else:
         assert outputs.model_output.attentions is None
-    if trf_model.transformer_config.get("output_hidden_states", None) is True:
+    if trf_model.transformer.config.output_hidden_states is True:
         assert outputs.model_output.hidden_states is not None
         assert all([t.shape[0] == shape[0] for t in outputs.model_output.hidden_states])
     else:

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -66,8 +66,15 @@ def test_predict(component, docs):
     n_tokens = trf_data.wordpieces.input_ids.shape[1]
     width = component.model.layers[0].attrs["width"]
     assert isinstance(trf_data, FullTransformerBatch)
-    assert len(trf_data.tensors.last_hidden_state) == component.model.layers[0].attrs["depth"]
-    assert trf_data.tensors.last_hidden_state[0].shape == (len(docs), n_tokens, width)
+    assert (
+        len(trf_data.model_output.last_hidden_state)
+        == component.model.layers[0].attrs["depth"]
+    )
+    assert trf_data.model_output.last_hidden_state[0].shape == (
+        len(docs),
+        n_tokens,
+        width,
+    )
 
 
 def test_set_annotations(component, docs):
@@ -250,7 +257,7 @@ def _assert_empty(trf_data):
     assert trf_data.wordpieces.strings == []
     assert trf_data.wordpieces.input_ids.size == 0
     assert trf_data.wordpieces.attention_mask.size == 0
-    assert trf_data.tensors == []
+    assert trf_data.tensors == ()
     assert len(trf_data.align.data) == 0
 
 

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -257,7 +257,7 @@ def _assert_empty(trf_data):
     assert trf_data.wordpieces.strings == []
     assert trf_data.wordpieces.input_ids.size == 0
     assert trf_data.wordpieces.attention_mask.size == 0
-    assert trf_data.tensors == ()
+    assert trf_data.tensors == []
     assert len(trf_data.align.data) == 0
 
 

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -152,7 +152,7 @@ cfg_string = """
     name = "custom_upstream"
 
     [components.transformer.model]
-    @architectures = "spacy-transformers.TransformerModel.v1"
+    @architectures = "spacy-transformers.TransformerModel.v2"
     name = "albert-base-v2"
 
     [components.transformer.model.transformer_config]

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -142,6 +142,13 @@ cfg_string = """
     [components.transformer]
     factory = "transformer"
     name = "custom_upstream"
+
+    [components.transformer.model]
+    @architectures = "spacy-transformers.TransformerModel.v1"
+    name = "albert-base-v2"
+
+    [components.transformer.model.transformer_config]
+    output_attentions = true
     """
 
 
@@ -295,6 +302,9 @@ def test_replace_listeners():
         losses = {}
         nlp.update(examples, sgd=optimizer, losses=losses)
         assert losses["tagger"] > 0.0
+
+    # check for presence of pooling_output in tensors
+    assert len(doc2._.trf_data.tensors) == 2
 
 
 def test_replace_listeners_invalid():

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -64,10 +64,10 @@ def test_init(component):
 def test_predict(component, docs):
     trf_data = component.predict(docs)
     assert isinstance(trf_data, FullTransformerBatch)
-    assert len(trf_data.tensors) == component.model.layers[0].attrs["depth"]
+    assert len(trf_data.tensors.last_hidden_state) == component.model.layers[0].attrs["depth"]
     n_tokens = trf_data.wordpieces.input_ids.shape[1]
     width = component.model.layers[0].attrs["width"]
-    assert trf_data.tensors[-1].shape == (len(docs), n_tokens, width)
+    assert trf_data.tensors.last_hidden_state[0].shape == (len(docs), n_tokens, width)
 
 
 def test_set_annotations(component, docs):

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -63,10 +63,10 @@ def test_init(component):
 
 def test_predict(component, docs):
     trf_data = component.predict(docs)
-    assert isinstance(trf_data, FullTransformerBatch)
-    assert len(trf_data.tensors.last_hidden_state) == component.model.layers[0].attrs["depth"]
     n_tokens = trf_data.wordpieces.input_ids.shape[1]
     width = component.model.layers[0].attrs["width"]
+    assert isinstance(trf_data, FullTransformerBatch)
+    assert len(trf_data.tensors.last_hidden_state) == component.model.layers[0].attrs["depth"]
     assert trf_data.tensors.last_hidden_state[0].shape == (len(docs), n_tokens, width)
 
 

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -303,8 +303,8 @@ def test_replace_listeners():
         nlp.update(examples, sgd=optimizer, losses=losses)
         assert losses["tagger"] > 0.0
 
-    # check for presence of pooling_output in tensors
-    assert len(doc2._.trf_data.tensors) == 2
+    # check for presence of pooler_output in tensors
+    assert doc2._.trf_data.model_output.pooler_output is not None
 
 
 def test_replace_listeners_invalid():

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -257,7 +257,7 @@ def _assert_empty(trf_data):
     assert trf_data.wordpieces.strings == []
     assert trf_data.wordpieces.input_ids.size == 0
     assert trf_data.wordpieces.attention_mask.size == 0
-    assert trf_data.tensors == []
+    assert trf_data.tensors == ()
     assert len(trf_data.align.data) == 0
 
 

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -310,8 +310,9 @@ def test_replace_listeners():
         nlp.update(examples, sgd=optimizer, losses=losses)
         assert losses["tagger"] > 0.0
 
-    # check for presence of pooler_output in tensors
+    # check for presence of additional fields in model_output
     assert doc2._.trf_data.model_output.pooler_output is not None
+    assert doc2._.trf_data.model_output.attentions is not None
 
 
 def test_replace_listeners_invalid():

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -14,16 +14,25 @@ def test_serialize_transformer_data():
     assert isinstance(new_data["x"], TransformerData)
 
     nlp = Language()
-    trf = nlp.add_pipe("transformer", config={"model": {"name": "distilbert-base-uncased", "transformer_config": {"output_attentions": True}}})
+    trf = nlp.add_pipe(
+        "transformer",
+        config={
+            "model": {
+                "name": "distilbert-base-uncased",
+                "transformer_config": {"output_attentions": True},
+            }
+        },
+    )
     nlp.initialize()
     doc = nlp("This is a test.")
     b = doc.to_bytes()
     reloaded_doc = Doc(nlp.vocab)
     reloaded_doc.from_bytes(b)
     assert_docs_equal(doc, reloaded_doc)
-    assert_array_equal(doc._.trf_data.tensors, reloaded_doc._.trf_data.tensors)
     for key in doc._.trf_data.model_output:
-        assert_array_equal(doc._.trf_data.model_output[key], reloaded_doc._.trf_data.model_output[key])
+        assert_array_equal(
+            doc._.trf_data.model_output[key], reloaded_doc._.trf_data.model_output[key]
+        )
 
 
 def test_transformer_tobytes():

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -1,7 +1,10 @@
 from spacy import Language
+from spacy.tests.util import assert_docs_equal
+from spacy.tokens import Doc
 
 from spacy_transformers import TransformerData
 import srsly
+from numpy.testing import assert_array_equal
 
 
 def test_serialize_transformer_data():
@@ -9,6 +12,18 @@ def test_serialize_transformer_data():
     bytes_data = srsly.msgpack_dumps(data)
     new_data = srsly.msgpack_loads(bytes_data)
     assert isinstance(new_data["x"], TransformerData)
+
+    nlp = Language()
+    trf = nlp.add_pipe("transformer", config={"model": {"name": "distilbert-base-uncased", "transformer_config": {"output_attentions": True}}})
+    nlp.initialize()
+    doc = nlp("This is a test.")
+    b = doc.to_bytes()
+    reloaded_doc = Doc(nlp.vocab)
+    reloaded_doc.from_bytes(b)
+    assert_docs_equal(doc, reloaded_doc)
+    assert_array_equal(doc._.trf_data.tensors, reloaded_doc._.trf_data.tensors)
+    for key in doc._.trf_data.model_output:
+        assert_array_equal(doc._.trf_data.model_output[key], reloaded_doc._.trf_data.model_output[key])
 
 
 def test_transformer_tobytes():

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -136,6 +136,17 @@ def test_transformer_pipeline_todisk_settings():
             trf2.model._init_tokenizer_config["use_fast"] = False
 
 
+def test_transformer_pipeline_todisk_before_initialize():
+    nlp = English()
+    trf = nlp.add_pipe("transformer", config=DEFAULT_CONFIG)
+    with make_tempdir() as d:
+        # serialize before initialization
+        nlp.to_disk(d)
+        nlp2 = spacy.load(d)
+        nlp2.initialize()
+        assert "last_hidden_state" in nlp2("test")._.trf_data.model_output
+
+
 inline_cfg_string = """
     [nlp]
     lang = "en"

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -1,3 +1,4 @@
+import pytest
 import spacy
 from spacy import Language
 from spacy.lang.en import English
@@ -124,6 +125,12 @@ def test_transformer_pipeline_todisk_settings():
             is True
         )
         assert nlp2("test")._.trf_data.model_output.attentions is not None
+        # after deserialization the init configs are empty SimpleFrozenDicts
+        assert nlp2.get_pipe("transformer").model._init_tokenizer_config == {}
+        with pytest.raises(NotImplementedError):
+            nlp2.get_pipe("transformer").model._init_tokenizer_config[
+                "use_fast"
+            ] = False
 
 
 inline_cfg_string = """

--- a/spacy_transformers/tests/test_tok2vectransformer.py
+++ b/spacy_transformers/tests/test_tok2vectransformer.py
@@ -77,7 +77,9 @@ def test_transformer_pipeline_tagger_internal():
         tagger_trf2 = tagger2.model.get_ref("tok2vec").layers[0]
         doc_tensor2 = tagger_trf2.predict([doc2])
         with pytest.raises(AssertionError):
-            assert_equal(doc_tensor2.doc_data[0].tensors, doc_tensor.doc_data[0].tensors)
+            assert_equal(
+                doc_tensor2.doc_data[0].tensors, doc_tensor.doc_data[0].tensors
+            )
 
         # results ARE the same if we call from_disk
         nlp2.from_disk(file_path)

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Union
 import torch
 import copy
+from transformers.modeling_outputs import BaseModelOutput
 
 from spacy.tokens import Doc
 from thinc.api import Model
@@ -114,7 +115,7 @@ def DummyTransformerModel(width: int, depth: int):
         shape = (tokens.input_ids.shape[0], tokens.input_ids.shape[1], width)
         for i in range(depth):
             tensors.append(torch.zeros(*shape))
-        return tensors, lambda d_tensors: tokens
+        return BaseModelOutput(last_hidden_state=tensors), lambda d_tensors: tokens
 
     return Model(
         "dummy-transformer",

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -127,7 +127,7 @@ def DummyTransformer(
     depth: int = 2, width: int = 4, get_spans=get_doc_spans
 ) -> Model[List[Doc], FullTransformerBatch]:
     """Create a test model that produces a FullTransformerBatch object."""
-    hf_model = HFObjects(None, DummyTokenizer())
+    hf_model = HFObjects(DummyTokenizer(), None)
 
     return DummyModel(
         "dummy-transformer",

--- a/spacy_transformers/tests/util.py
+++ b/spacy_transformers/tests/util.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Union
 import torch
 import copy
-from transformers.modeling_outputs import BaseModelOutput
+from transformers.file_utils import ModelOutput
 
 from spacy.tokens import Doc
 from thinc.api import Model
@@ -111,11 +111,9 @@ def DummyTransformerModel(width: int, depth: int):
     def _forward(model, tokens, is_train):
         width = model.attrs["width"]
         depth = model.attrs["depth"]
-        tensors = []
-        shape = (tokens.input_ids.shape[0], tokens.input_ids.shape[1], width)
-        for i in range(depth):
-            tensors.append(torch.zeros(*shape))
-        return BaseModelOutput(last_hidden_state=tensors), lambda d_tensors: tokens
+        shape = (depth, tokens.input_ids.shape[0], tokens.input_ids.shape[1], width)
+        tensors = torch.zeros(*shape)
+        return ModelOutput(last_hidden_state=tensors), lambda d_tensors: tokens
 
     return Model(
         "dummy-transformer",
@@ -137,7 +135,7 @@ def DummyTransformer(
             "tokenizer": DummyTokenizer(),
             "grad_factor": 1.0,
             "flush_cache_chance": 0.0,
-            "transformer_config": {}
+            "transformer_config": {},
         },
         dims={"nO": width},
     )

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -72,17 +72,6 @@ def maybe_flush_pytorch_cache(chance: float = 1.0):
         torch.cuda.empty_cache()
 
 
-def find_last_hidden(tensors) -> int:
-    """Find the index of the hidden layer in a list of activation tensors.
-    Internals.
-    """
-    for i, tensor in reversed(list(enumerate(tensors))):
-        if len(tensor.shape) == 3:
-            return i
-    else:
-        raise ValueError("No 3d tensors")
-
-
 def transpose_list(nested_list):
     output = []
     for i, entry in enumerate(nested_list):

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -1,8 +1,7 @@
 from typing import List, Dict, Union
 from pathlib import Path
-from functools import partial
 import random
-from transformers import AutoModel, AutoTokenizer
+from transformers import AutoConfig, AutoModel, AutoTokenizer
 from transformers.tokenization_utils import BatchEncoding
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 import catalogue
@@ -36,9 +35,9 @@ def huggingface_from_pretrained(
     else:
         str_path = source
     tokenizer = AutoTokenizer.from_pretrained(str_path, **tok_config)
-    transformer = AutoModel.from_pretrained(str_path)
     trf_config["return_dict"] = True
-    transformer.forward = partial(transformer.forward, **trf_config)
+    config = AutoConfig.from_pretrained(str_path, **trf_config)
+    transformer = AutoModel.from_config(config)
     ops = get_current_ops()
     if isinstance(ops, CupyOps):
         transformer.cuda()

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -34,6 +34,7 @@ def huggingface_from_pretrained(
         str_path = source
     tokenizer = AutoTokenizer.from_pretrained(str_path, **tok_config)
     transformer = AutoModel.from_pretrained(str_path)
+    trf_config["return_dict"] = True
     transformer.forward = partial(transformer.forward, **trf_config)
     ops = get_current_ops()
     if isinstance(ops, CupyOps):


### PR DESCRIPTION
* Save model output as `ModelOutput` instead of a list of tensors in `TransformerData.model_output` and `FullTransformerBatch.model_output`.

  * For backwards compatibility with transformers v3 set `return_dict = True` in the transformer config.

* `TransformerData.tensors` and `FullTransformerBatch.tensors` return `ModelOutput.to_tuple()`.

* Store any additional model output as `ModelOutput` in `TransformerData.model_output`.

  * Save all `torch.Tensor` and `tuple(torch.Tensor)` values in `TransformerData.model_output` for cases where `tensor.shape[0]` is the batch size so that it's possible to slice the output for individual docs.
      * Includes: `pooler_output`, `hidden_states`, `attentions`, and `cross_attentions`

* Re-enable tests for `gpt2` and `xlnet` in the CI.

* Following #285, include some minor modifications and bug fixes for `HFShim` and `HFObjects`
  * Rename the temporary init-only configs in `HFObjects` and don't serialize them in `HFShim` once the model is initialized