### PR TITLE
v2 architectures for transformer_config

### DIFF
--- a/examples/configs/joint-core-bert.cfg
+++ b/examples/configs/joint-core-bert.cfg
@@ -86,9 +86,10 @@ min_action_freq = 1
 # to a batch of Doc objects, which are preprocessed into Span objects to support
 # longer documents.
 [components.transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v2"
 name = "roberta-base"
 tokenizer_config = {"use_fast": true}
+transformer_config = {"output_attentions": false}
 
 [components.transformer.model.get_spans]
 # You can set a custom strategy for preparing spans from the batch, e.g. you

--- a/examples/configs/ner-albert.cfg
+++ b/examples/configs/ner-albert.cfg
@@ -54,9 +54,10 @@ maxout_pieces = 3
 use_upper = false
 
 [nlp.pipeline.ner.model.tok2vec]
-@architectures = "spacy.Tok2VecTransformer.v1"
+@architectures = "spacy.Tok2VecTransformer.v2"
 name = "albert-base-v2"
 tokenizer_config = {"use_fast": false}
+transformer_config = {"output_attentions": false}
 grad_factor = 1.0
 
 [nlp.pipeline.ner.model.tok2vec.get_spans]

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,9 @@ spacy_factories =
 spacy_architectures =
     spacy-transformers.TransformerListener.v1 = spacy_transformers:architectures.transformer_listener_tok2vec_v1
     spacy-transformers.Tok2VecTransformer.v1 = spacy_transformers:architectures.transformer_tok2vec_v1
-    spacy-transformers.TransformerModel.v1 = spacy_transformers:architectures.create_TransformerModel
+    spacy-transformers.Tok2VecTransformer.v2 = spacy_transformers:architectures.transformer_tok2vec_v2
+    spacy-transformers.TransformerModel.v1 = spacy_transformers:architectures.create_TransformerModel_v1
+    spacy-transformers.TransformerModel.v2 = spacy_transformers:architectures.create_TransformerModel_v2
 
 [bdist_wheel]
 universal = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.0.3
+version = 1.1.0
 description = spaCy pipelines for pre-trained BERT and other transformers
 url = https://spacy.io
 author = Explosion

--- a/spacy_transformers/architectures.py
+++ b/spacy_transformers/architectures.py
@@ -112,7 +112,17 @@ def transformer_tok2vec_v2(
 
 
 @registry.architectures.register("spacy-transformers.TransformerModel.v1")
-def create_TransformerModel(
+def create_TransformerModel_v1(
+    name: str,
+    get_spans: Callable,
+    tokenizer_config: dict = {},
+) -> Model[List[Doc], "FullTransformerBatch"]:
+    model = TransformerModel(name, get_spans, tokenizer_config)
+    return model
+
+
+@registry.architectures.register("spacy-transformers.TransformerModel.v2")
+def create_TransformerModel_v2(
     name: str,
     get_spans: Callable,
     tokenizer_config: dict = {},

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -30,7 +30,7 @@ max_batch_items = 4096
 @architectures = "spacy-transformers.TransformerModel.v2"
 name = "roberta-base"
 tokenizer_config = {"use_fast": true}
-transformer_config = {"output_attentions": false}
+transformer_config = {}
 
 [transformer.model.get_spans]
 @span_getters = "spacy-transformers.strided_spans.v1"

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -27,7 +27,7 @@ max_batch_items = 4096
 @annotation_setters = "spacy-transformers.null_annotation_setter.v1"
 
 [transformer.model]
-@architectures = "spacy-transformers.TransformerModel.v1"
+@architectures = "spacy-transformers.TransformerModel.v2"
 name = "roberta-base"
 tokenizer_config = {"use_fast": true}
 transformer_config = {"output_attentions": false}

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -263,7 +263,7 @@ def test_replace_listeners():
     assert isinstance(transformer.model, TransformerModel)
     assert (
         nlp.config["components"]["transformer"]["model"]["@architectures"]
-        == "spacy-transformers.TransformerModel.v1"
+        == "spacy-transformers.TransformerModel.v2"
     )
     assert (
         nlp.config["components"]["tagger"]["model"]["tok2vec"]["@architectures"]

--- a/spacy_transformers/tests/test_serialize.py
+++ b/spacy_transformers/tests/test_serialize.py
@@ -12,7 +12,7 @@ from ..util import make_tempdir
 
 DEFAULT_CONFIG = {
     "model": {
-        "@architectures": "spacy-transformers.TransformerModel.v1",
+        "@architectures": "spacy-transformers.TransformerModel.v2",
         "name": "distilbert-base-uncased",
     }
 }
@@ -95,9 +95,10 @@ inline_cfg_string = """
     nO = null
 
     [components.tagger.model.tok2vec]
-    @architectures = "spacy-transformers.Tok2VecTransformer.v1"
+    @architectures = "spacy-transformers.Tok2VecTransformer.v2"
     name = "distilbert-base-uncased"
     tokenizer_config = {"use_fast": true}
+    transformer_config = {"output_attentions": false}
     grad_factor = 1.0
 
     [components.tagger.model.tok2vec.get_spans]


### PR DESCRIPTION
Follow up on https://github.com/explosion/spacy-transformers/pull/268: 
- `TransformerModel.v2` takes new argument `transformer_config`
- updated example configs with new argument
- docs will be added to spaCy

Also bumping the version to 1.1.0