### PR TITLE
Use CPU arrays for tokenization output

### DIFF
--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -4,7 +4,7 @@ import torch
 import numpy
 from transformers.tokenization_utils import BatchEncoding
 from thinc.types import Ragged, Floats3d, FloatsXd, Ints2d
-from thinc.api import get_array_module, xp2torch, torch2xp
+from thinc.api import NumpyOps, get_array_module, xp2torch, torch2xp
 from spacy.tokens import Span
 import srsly
 
@@ -97,13 +97,16 @@ class WordpieceBatch:
             for tokens in token_data["input_texts"]
         ]
         n_seq = len(lengths)
+
+        numpy_ops = NumpyOps()
+
         return cls(
             strings=token_data["input_texts"],
-            input_ids=torch2xp(token_data["input_ids"]).reshape((n_seq, -1)),
-            attention_mask=torch2xp(token_data["attention_mask"]).reshape((n_seq, -1)),
+            input_ids=numpy_ops.asarray2i(token_data["input_ids"]),
+            attention_mask=numpy_ops.asarray2f(token_data["attention_mask"]),
             lengths=lengths,
             token_type_ids=(
-                torch2xp(token_data["token_type_ids"]).reshape((n_seq, -1))
+                numpy_ops.asarray2i(token_data["token_type_ids"])
                 if "token_type_ids" in token_data
                 else None
             ),

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -211,12 +211,14 @@ def forward(
 
 def _convert_transformer_inputs(model, wps: WordpieceBatch, is_train):
     # Adapter for the HFWrapper. See https://thinc.ai/docs/usage-frameworks
+
+    hf_device = model.shims[0]._hfmodel.transformer.device
     kwargs = {
-        "input_ids": xp2torch(wps.input_ids),
-        "attention_mask": xp2torch(wps.attention_mask),
+        "input_ids": xp2torch(wps.input_ids).to(device=hf_device),
+        "attention_mask": xp2torch(wps.attention_mask).to(device=hf_device),
     }
     if wps.token_type_ids is not None:
-        kwargs["token_type_ids"] = xp2torch(wps.token_type_ids)
+        kwargs["token_type_ids"] = xp2torch(wps.token_type_ids).to(device=hf_device)
     return ArgsKwargs(args=(), kwargs=kwargs), lambda dX: []
 
 

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -46,12 +46,16 @@ def huggingface_from_pretrained(
 
 def huggingface_tokenize(tokenizer, texts: List[str]) -> BatchEncoding:
     """Apply a Huggingface tokenizer to a batch of texts."""
+
+    # Use NumPy arrays rather than PyTorch tensors to avoid a lot of
+    # host <-> device transfers during tokenization and post-processing
+    # when a GPU is used.
     token_data = tokenizer(
         texts,
         add_special_tokens=True,
         return_attention_mask=True,
         return_offsets_mapping=isinstance(tokenizer, PreTrainedTokenizerFast),
-        return_tensors="pt",
+        return_tensors="np",
         return_token_type_ids=None,  # Sets to model default
         padding="longest",
     )


### PR DESCRIPTION
Tokenizers were called with the option to return PyTorch Tensors. Since Thinc sets the default tensor type to torch.cuda.FloatTensor when GPU support is enabled, the tokenization Tensors were allocated on the GPU. This resulted in many host <-> device transfers during tokenization and post-processing.

To reduce the number of transfers, this change allocates the tokenization output as numpy arrays instead. The arrays are only
copied to the GPU when they are used as the input to a transformer.

Performance of finetuning roberta-base for tagging (RTX 2060 Super):

- Before: ~5800 words per second
- After: ~7350 words per second

Profile before this change:

<img width="681" alt="Screen Shot 2021-08-26 at 09 29 47" src="https://user-images.githubusercontent.com/49398/130943187-4319bc87-b1b4-47f9-901c-5dfc6032e919.png">

Profile after this change (not exactly the same batch, but the time spent in tokenization is now comparatively small):

<img width="965" alt="Screen Shot 2021-08-26 at 11 28 06" src="https://user-images.githubusercontent.com/49398/130943233-c29a4cdf-9fe0-46d9-a75e-1917c91c3ac6.png">
