### PR TITLE
Convert token identifiers to Long for torch < 1.8.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,11 @@ jobs:
       pip uninstall -y -r installed.txt
     displayName: "Uninstall all packages"
 
+  - script: |
+      pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
+    displayName: 'Install oldest supported torch for python 3.6'
+    condition: eq($(python.version), '3.6')
+
   - script: pip install dist/*.tar.gz
     displayName: 'Install from sdist'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
   - script: |
       pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
     displayName: 'Install oldest supported torch for python 3.6'
-    condition: eq($(python.version), '3.6')
+    condition: eq('$(python.version)', '3.6')
 
   - script: pip install dist/*.tar.gz
     displayName: 'Install from sdist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
   - script: |
       pip install "torch==1.6.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
     displayName: 'Install oldest supported torch for python 3.6'
-    condition: eq('$(python.version)', '3.6')
+    condition: eq(variables['python.version'], '3.6')
 
   - script: pip install dist/*.tar.gz
     displayName: 'Install from sdist'

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -205,7 +205,8 @@ def _convert_transformer_inputs(model, wps: WordpieceBatch, is_train):
 
     hf_device = model.shims[0]._hfmodel.transformer.device
     kwargs = {
-        "input_ids": xp2torch(wps.input_ids).to(device=hf_device),
+        # Note: remove conversion to long when PyTorch >= 1.8.0.
+        "input_ids": xp2torch(wps.input_ids).long().to(device=hf_device),
         "attention_mask": xp2torch(wps.attention_mask).to(device=hf_device),
     }
     if wps.token_type_ids is not None:

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -210,7 +210,7 @@ def _convert_transformer_inputs(model, wps: WordpieceBatch, is_train):
         "attention_mask": xp2torch(wps.attention_mask).to(device=hf_device),
     }
     if wps.token_type_ids is not None:
-        kwargs["token_type_ids"] = xp2torch(wps.token_type_ids).to(device=hf_device)
+        kwargs["token_type_ids"] = xp2torch(wps.token_type_ids).long().to(device=hf_device)
     return ArgsKwargs(args=(), kwargs=kwargs), lambda dX: []
 
 


### PR DESCRIPTION
Since PyTorch 1.8.0 token identifiers can be both Int and Long for
embedding lookups. Prior versions only support Long. Since we still
support older versions, convert token identifiers to Long for
compatibility.

This fixes the incompatibility with older versions introduced in #289.