### PR TITLE
Fixing ModelOutput training

### DIFF
--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -180,8 +180,10 @@ class TransformerData:
         )
 
     @property
-    def tensors(self) -> Tuple[Union[FloatsXd, List[FloatsXd]]]:
-        return self.model_output.to_tuple()
+    def tensors(self, exlude=EXCLUDED_KEYS) -> Tuple[Union[FloatsXd, List[FloatsXd]]]:
+        return tuple(
+            self.model_output[k] for k in self.model_output.keys() if k not in exlude
+        )
 
     @property
     def tokens(self) -> Dict[str, Any]:
@@ -274,8 +276,12 @@ class FullTransformerBatch:
         )
 
     @property
-    def tensors(self) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor]]]:
-        return self.model_output.to_tuple()
+    def tensors(
+        self, exlude=EXCLUDED_KEYS
+    ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor]]]:
+        return tuple(
+            self.model_output[k] for k in self.model_output.keys() if k not in exlude
+        )
 
     @property
     def tokens(self) -> Dict[str, Any]:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -13,6 +13,9 @@ from .util import transpose_list
 from .align import get_token_positions
 
 
+EXCLUDED_KEYS = ("attentions",)
+
+
 @dataclass
 class WordpieceBatch:
     """Holds data from the transformers BatchEncoding class.


### PR DESCRIPTION
Follow-up for https://github.com/explosion/spacy-transformers/pull/283

When inspecting the model training with the `ModelOutput` changes, `unsplit_by_doc` received a different dimension for the `arrays` input parameter: basically the `pooler_output` tensor would be missing. I think the `backprop` in `_convert_transformer_outputs` should include all tensors - not just the last hidden state.

To make that work, the `d_model_output` object holding the gradients in `backprop_trf_to_tensor` should have the same keys as the original object.

In all of this, `"attentions"` should be excluded though. It feels kind of bad to hardcode this, but it is a specifically defined field in [`BaseModelOutput`](https://huggingface.co/transformers/main_classes/output.html#basemodeloutput) so I think it's fine?

I haven't yet tested this on a serious training dataset though, so I'll keep this in draft until we've had a chance to test further 🤞 