### PR TITLE
Import get_current_ops from thinc.api

### DIFF
--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -3,8 +3,8 @@ from io import BytesIO
 from pathlib import Path
 import srsly
 import torch
+from thinc.api import get_current_ops
 from spacy.util import SimpleFrozenDict
-from spacy.vectors import get_current_ops
 
 from ..data_classes import HFObjects
 from ..util import make_tempdir


### PR DESCRIPTION
`get_current_ops` was imported from `spacy.vectors`. But that function is a re-export of `thinc.api.get_current_ops`. Use `thinc.api.get_current_ops` instead.
