### PR TITLE
Add `build-constraints.txt`

### DIFF
--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,0 +1,6 @@
+# build version constraints for use with wheelwright + multibuild
+numpy==1.15.0; python_version<='3.7'
+numpy==1.17.3; python_version=='3.8'
+numpy==1.19.3; python_version=='3.9'
+numpy==1.21.3; python_version=='3.10'
+numpy; python_version>='3.11'


### PR DESCRIPTION
Keeping in line with [spaCy](https://github.com/explosion/spaCy/blob/master/build-constraints.txt) and [thinc](https://github.com/explosion/thinc/blob/master/build-constraints.txt), and for use when running GPU tests on BuildKite.