### PR TITLE
Fix tests: do not rely on `name` in configuration

### DIFF
--- a/spacy_transformers/tests/test_configs.py
+++ b/spacy_transformers/tests/test_configs.py
@@ -32,15 +32,14 @@ cfg_string = """
     [components.tagger.model.tok2vec]
     @architectures = "spacy-transformers.TransformerListener.v1"
     grad_factor = 1.0
-    upstream = ${components.transformer.name}
+    upstream = "transformer"
 
     [components.tagger.model.tok2vec.pooling]
     @layers = "reduce_mean.v1"
 
     [components.transformer]
     factory = "transformer"
-    name = "custom_upstream"
-    
+
     [corpora]
     @readers = toy_tagger_data.v1
     

--- a/spacy_transformers/tests/test_configs.py
+++ b/spacy_transformers/tests/test_configs.py
@@ -18,7 +18,7 @@ TRAIN_TAGGER_DATA = [
 cfg_string = """
     [nlp]
     lang = "en"
-    pipeline = ["transformer","tagger"]
+    pipeline = ["custom_transformer","tagger"]
 
     [components]
 
@@ -32,12 +32,12 @@ cfg_string = """
     [components.tagger.model.tok2vec]
     @architectures = "spacy-transformers.TransformerListener.v1"
     grad_factor = 1.0
-    upstream = "transformer"
+    upstream = "custom_transformer"
 
     [components.tagger.model.tok2vec.pooling]
     @layers = "reduce_mean.v1"
 
-    [components.transformer]
+    [components.custom_transformer]
     factory = "transformer"
 
     [corpora]
@@ -69,3 +69,9 @@ def test_init_nlp(config_string):
     config = Config(DEFAULT_CONFIG, section_order=CONFIG_SECTION_ORDER).merge(config)
     nlp = init_nlp(config, use_gpu=False)
     assert nlp is not None
+
+    tagger = nlp.get_pipe("tagger")
+    transformer = nlp.get_pipe("custom_transformer")
+    tagger_trf = tagger.model.get_ref("tok2vec").layers[0]
+    assert tagger_trf.upstream_name == "custom_transformer"
+    assert transformer.listeners[0] == tagger_trf

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -145,7 +145,7 @@ cfg_string = """
     [components.senter.model.tok2vec]
     @architectures = "spacy-transformers.TransformerListener.v1"
     grad_factor = 1.0
-    upstream = ${components.transformer.name}
+    upstream = "transformer"
 
     [components.senter.model.tok2vec.pooling]
     @layers = "reduce_mean.v1"
@@ -160,14 +160,13 @@ cfg_string = """
     [components.tagger.model.tok2vec]
     @architectures = "spacy-transformers.TransformerListener.v1"
     grad_factor = 1.0
-    upstream = ${components.transformer.name}
+    upstream = "transformer"
 
     [components.tagger.model.tok2vec.pooling]
     @layers = "reduce_mean.v1"
 
     [components.transformer]
     factory = "transformer"
-    name = "custom_upstream"
 
     [components.transformer.model]
     @architectures = "spacy-transformers.TransformerModel.v3"
@@ -189,7 +188,6 @@ def test_transformer_pipeline_tagger_senter_listener():
     tagger_trf = tagger.model.get_ref("tok2vec").layers[0]
     assert isinstance(transformer, Transformer)
     assert isinstance(tagger_trf, TransformerListener)
-    assert tagger_trf.upstream_name == "custom_upstream"
     train_examples = []
     for t in TRAIN_DATA:
         train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))


### PR DESCRIPTION
The `name` attribute in the configuration of the transformer pipe is ignored since the merge of spaCy#10779, so do not use it in tests.
