### PR TITLE
Convert all transformer outputs to XP arrays at once

### DIFF
--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -6,6 +6,7 @@ from transformers.tokenization_utils import BatchEncoding
 from transformers.file_utils import ModelOutput
 from thinc.types import Ragged, Floats2d, Floats3d, FloatsXd, Ints2d
 from thinc.api import NumpyOps, get_array_module, xp2torch, torch2xp
+from thinc.util import is_xp_array
 from spacy.tokens import Span
 import srsly
 
@@ -314,6 +315,21 @@ class FullTransformerBatch:
         for doc_spans in self.spans:
             flat_spans.extend(doc_spans)
         token_positions = get_token_positions(flat_spans)
+
+        # Convert all outputs to ops tensors.
+        xp_model_output = ModelOutput()
+        last_hidden_state = self.model_output.last_hidden_state
+        for key, output in self.model_output.items():
+            if isinstance(output, torch.Tensor):
+                xp_model_output[key] = torch2xp(output)
+            elif (
+                isinstance(output, tuple)
+                and all(isinstance(t, torch.Tensor) for t in output)
+                and all(t.shape[0] == last_hidden_state.shape[0] for t in output)
+            ):
+                xp_model_output[key] = [torch2xp(t) for t in output]
+
+        # Split outputs per doc.
         outputs = []
         start = 0
         prev_tokens = 0
@@ -328,16 +344,13 @@ class FullTransformerBatch:
             doc_align = self.align[start_i:end_i]
             doc_align.data = doc_align.data - prev_tokens
             model_output = ModelOutput()
-            last_hidden_state = self.model_output.last_hidden_state
-            for key, output in self.model_output.items():
-                if isinstance(output, torch.Tensor):
-                    model_output[key] = torch2xp(output[start:end])
-                elif (
-                    isinstance(output, tuple)
-                    and all(isinstance(t, torch.Tensor) for t in output)
-                    and all(t.shape[0] == last_hidden_state.shape[0] for t in output)
-                ):
-                    model_output[key] = [torch2xp(t[start:end]) for t in output]
+            for key, output in xp_model_output.items():
+                # After the torch2xp conversion above, we only XP arrays and
+                # lists of XP arrays.
+                if not isinstance(output, list):
+                    model_output[key] = output[start:end]
+                else:
+                    model_output[key] = [t[start:end] for t in output]
             outputs.append(
                 TransformerData(
                     wordpieces=doc_tokens,

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -315,7 +315,7 @@ class FullTransformerBatch:
             flat_spans.extend(doc_spans)
         token_positions = get_token_positions(flat_spans)
 
-        # Convert all outputs to ops tensors.
+        # Convert all outputs to XP arrays.
         xp_model_output = ModelOutput()
         last_hidden_state = self.model_output.last_hidden_state
         for key, output in self.model_output.items():
@@ -328,7 +328,7 @@ class FullTransformerBatch:
             ):
                 xp_model_output[key] = [torch2xp(t) for t in output]
 
-        # Split outputs per doc.
+        # Split outputs per Doc.
         outputs = []
         start = 0
         prev_tokens = 0
@@ -344,8 +344,8 @@ class FullTransformerBatch:
             doc_align.data = doc_align.data - prev_tokens
             model_output = ModelOutput()
             for key, output in xp_model_output.items():
-                # After the torch2xp conversion above, we only XP arrays and
-                # lists of XP arrays.
+                # After the torch2xp conversion above, we only have XP arrays
+                # and lists of XP arrays.
                 if not isinstance(output, list):
                     model_output[key] = output[start:end]
                 else:

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -6,7 +6,6 @@ from transformers.tokenization_utils import BatchEncoding
 from transformers.file_utils import ModelOutput
 from thinc.types import Ragged, Floats2d, Floats3d, FloatsXd, Ints2d
 from thinc.api import NumpyOps, get_array_module, xp2torch, torch2xp
-from thinc.util import is_xp_array
 from spacy.tokens import Span
 import srsly
 


### PR DESCRIPTION
`FullTransformerBatch.split_by_doc` splits up transformer output by document and converts the document output from PyTorch `Tensor`s to XP arrays. This results in many small conversions. In most cases, this is not an issue, e.g. when converting from PyTorch CUDA `Tensor`s to CuPy CUDA arrays, the efficient dlpack conversion is used. However, this is not always the case. For example, for MPSOps, the outputs are copied from PyTorch MPS `Tensor`s to NumPy arrays, resulting in many small conversions/transfers, as can be seen in the following profile:

<img width="1097" alt="Screen Shot 2022-06-03 at 11 04 09" src="https://user-images.githubusercontent.com/49398/171832903-f73ead55-8905-4b09-b3f0-0655f82262fc.png">

This change changes `split_by_doc` to first convert PyTorch `Tensor`s to XP arrays all at once. Then, when splitting by doc, these Cupy Arrays are sliced. In this way, we perform only one large array conversion:

<img width="849" alt="Screen Shot 2022-06-03 at 11 04 26" src="https://user-images.githubusercontent.com/49398/171833317-c817396c-2542-40ba-9f86-53fd66535bff.png">

For transformers on Metal Performance Shaders this gives a small, but consistent speedup (~7700 WPS -> 7800 WPS).