### PR TITLE
Support alternate model loaders in HFShim and HFWrapper

### DIFF
--- a/spacy_transformers/layers/hf_wrapper.py
+++ b/spacy_transformers/layers/hf_wrapper.py
@@ -1,8 +1,9 @@
 from typing import Callable, Optional, Any
 from thinc.layers.pytorchwrapper import forward as pt_forward
 from thinc.layers.pytorchwrapper import convert_pytorch_default_inputs, convert_pytorch_default_outputs
-
 from thinc.api import registry, Model
+
+from transformers import AutoConfig, AutoModel, AutoTokenizer
 
 from .hf_shim import HFShim
 
@@ -14,6 +15,9 @@ def HFWrapper(
     convert_outputs: Optional[Callable] = None,
     mixed_precision: bool = False,
     grad_scaler_config: dict = {},
+    config_cls = AutoConfig,
+    model_cls = AutoModel,
+    tokenizer_cls = AutoTokenizer,
 ) -> Model[Any, Any]:
     """Wrap a PyTorch HF model, so that it has the same API as Thinc models.
     To optimize the model, you'll need to create a PyTorch optimizer and call
@@ -50,6 +54,9 @@ def HFWrapper(
                 hf_model,
                 mixed_precision=mixed_precision,
                 grad_scaler_config=grad_scaler_config,
+                config_cls=config_cls,
+                model_cls=model_cls,
+                tokenizer_cls=tokenizer_cls,
             )
         ],
         dims={"nI": None, "nO": None},

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -234,7 +234,12 @@ def _convert_transformer_outputs(model, inputs_outputs, is_train):
 
 
 def huggingface_from_pretrained(
-    source: Union[Path, str], tok_config: Dict, trf_config: Dict
+    source: Union[Path, str],
+    tok_config: Dict,
+    trf_config: Dict,
+    config_cls = AutoConfig,
+    model_cls = AutoModel,
+    tokenizer_cls = AutoTokenizer,
 ) -> HFObjects:
     """Create a Huggingface transformer model from pretrained weights. Will
     download the model if it is not already downloaded.
@@ -248,14 +253,14 @@ def huggingface_from_pretrained(
         str_path = str(source.absolute())
     else:
         str_path = source
-    tokenizer = AutoTokenizer.from_pretrained(str_path, **tok_config)
+    tokenizer = tokenizer_cls.from_pretrained(str_path, **tok_config)
     vocab_file_contents = None
     if hasattr(tokenizer, "vocab_file"):
         with open(tokenizer.vocab_file, "rb") as fileh:
             vocab_file_contents = fileh.read()
     trf_config["return_dict"] = True
-    config = AutoConfig.from_pretrained(str_path, **trf_config)
-    transformer = AutoModel.from_pretrained(str_path, config=config)
+    config = config_cls.from_pretrained(str_path, **trf_config)
+    transformer = model_cls.from_pretrained(str_path, config=config)
     ops = get_current_ops()
     if isinstance(ops, CupyOps):
         transformer.cuda()

--- a/spacy_transformers/tests/test_model_sequence_classification.py
+++ b/spacy_transformers/tests/test_model_sequence_classification.py
@@ -1,0 +1,155 @@
+from typing import Callable
+from functools import partial
+import copy
+
+import spacy
+from spacy.util import make_tempdir
+
+from spacy_transformers.align import get_alignment
+from spacy_transformers.data_classes import HFObjects, WordpieceBatch
+from spacy_transformers.layers.hf_wrapper import HFWrapper
+from spacy_transformers.layers.transformer_model import (
+    _convert_transformer_inputs,
+    _convert_transformer_outputs,
+    forward,
+    huggingface_from_pretrained,
+    huggingface_tokenize,
+    set_pytorch_transformer,
+)
+from spacy_transformers.span_getters import get_strided_spans
+from spacy_transformers.truncate import truncate_oversize_splits
+from thinc.api import Model
+
+import torch
+from transformers import AutoModelForSequenceClassification
+from transformers.models.distilbert.modeling_distilbert import DistilBertForSequenceClassification
+from transformers.modeling_outputs import SequenceClassifierOutput
+
+
+def test_model_for_sequence_classification():
+    # adapted from https://github.com/KennethEnevoldsen/spacy-wrap/
+    class ClassificationTransformerModel(Model):
+        def __init__(
+            self,
+            name: str,
+            get_spans: Callable,
+            tokenizer_config: dict = {},
+            transformer_config: dict = {},
+            mixed_precision: bool = False,
+            grad_scaler_config: dict = {},
+        ):
+            hf_model = HFObjects(None, None, None, tokenizer_config, transformer_config)
+            wrapper = HFWrapper(
+                hf_model,
+                convert_inputs=_convert_transformer_inputs,
+                convert_outputs=_convert_transformer_outputs,
+                mixed_precision=mixed_precision,
+                grad_scaler_config=grad_scaler_config,
+                model_cls=AutoModelForSequenceClassification,
+            )
+            super().__init__(
+                "clf_transformer",
+                forward,
+                init=init,
+                layers=[wrapper],
+                dims={"nO": None},
+                attrs={
+                    "get_spans": get_spans,
+                    "name": name,
+                    "set_transformer": set_pytorch_transformer,
+                    "has_transformer": False,
+                    "flush_cache_chance": 0.0,
+                },
+            )
+
+        @property
+        def tokenizer(self):
+            return self.layers[0].shims[0]._hfmodel.tokenizer
+
+        @property
+        def transformer(self):
+            return self.layers[0].shims[0]._hfmodel.transformer
+
+        @property
+        def _init_tokenizer_config(self):
+            return self.layers[0].shims[0]._hfmodel._init_tokenizer_config
+
+        @property
+        def _init_transformer_config(self):
+            return self.layers[0].shims[0]._hfmodel._init_transformer_config
+
+        def copy(self):
+            """
+            Create a copy of the model, its attributes, and its parameters. Any child
+            layers will also be deep-copied. The copy will receive a distinct `model.id`
+            value.
+            """
+            copied = ClassificationTransformerModel(self.name, self.attrs["get_spans"])
+            params = {}
+            for name in self.param_names:
+                params[name] = self.get_param(name) if self.has_param(name) else None
+            copied.params = copy.deepcopy(params)
+            copied.dims = copy.deepcopy(self._dims)
+            copied.layers[0] = copy.deepcopy(self.layers[0])
+            for name in self.grad_names:
+                copied.set_grad(name, self.get_grad(name).copy())
+            return copied
+
+    def init(model: Model, X=None, Y=None):
+        if model.attrs["has_transformer"]:
+            return
+        name = model.attrs["name"]
+        tok_cfg = model._init_tokenizer_config
+        trf_cfg = model._init_transformer_config
+        hf_model = huggingface_from_pretrained(
+            name, tok_cfg, trf_cfg, model_cls=AutoModelForSequenceClassification
+        )
+        model.attrs["set_transformer"](model, hf_model)
+        tokenizer = model.tokenizer
+        # Call the model with a batch of inputs to infer the width
+        if X:
+            # If we're dealing with actual texts, do the work to setup the wordpieces
+            # batch properly
+            docs = X
+            get_spans = model.attrs["get_spans"]
+            nested_spans = get_spans(docs)
+            flat_spans = []
+            for doc_spans in nested_spans:
+                flat_spans.extend(doc_spans)
+            token_data = huggingface_tokenize(
+                tokenizer, [span.text for span in flat_spans]
+            )
+            wordpieces = WordpieceBatch.from_batch_encoding(token_data)
+            align = get_alignment(
+                flat_spans, wordpieces.strings, tokenizer.all_special_tokens
+            )
+            wordpieces, align = truncate_oversize_splits(
+                wordpieces, align, tokenizer.model_max_length
+            )
+        else:
+            texts = ["hello world", "foo bar"]
+            token_data = huggingface_tokenize(tokenizer, texts)
+            wordpieces = WordpieceBatch.from_batch_encoding(token_data)
+        model.layers[0].initialize(X=wordpieces)
+
+    model = ClassificationTransformerModel(
+        "sgugger/tiny-distilbert-classification",
+        get_spans=partial(get_strided_spans, window=128, stride=96),
+    )
+    model.initialize()
+
+    assert isinstance(model.transformer, DistilBertForSequenceClassification)
+    nlp = spacy.blank("en")
+    doc = nlp.make_doc("some text")
+    assert isinstance(model.predict([doc]).model_output, SequenceClassifierOutput)
+
+    b = model.to_bytes()
+    model_re = ClassificationTransformerModel(
+        "sgugger/tiny-distilbert-classification",
+        get_spans=partial(get_strided_spans, window=128, stride=96),
+    ).from_bytes(b)
+    assert isinstance(model_re.transformer, DistilBertForSequenceClassification)
+    assert isinstance(model_re.predict([doc]).model_output, SequenceClassifierOutput)
+    assert torch.equal(model.predict([doc]).model_output.logits, model_re.predict([doc]).model_output.logits)
+    # Note that model.to_bytes() != model_re.to_bytes(), but this is also not
+    # true for the default models.


### PR DESCRIPTION
In order to support other model loaders such as `AutoModelForSequenceClassification`, make the loading config / model / tokenizer classes configurable in `huggingface_from_pretrained`, `HFWrapper` and `HFShim`.