### PR TITLE
Add kwargs features of `from_pretrained()` in HFShim.from_bytes()

### DIFF
--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -89,13 +89,15 @@ class HFShim(PyTorchShim):
         config_dict = msg["config"]
         tok_dict = msg["tokenizer"]
         if config_dict:
+            tok_config = msg.get("_init_tokenizer_config", {})
+            trf_config = msg.get("_init_transformer_config", {})
             with make_tempdir() as temp_dir:
                 config_file = temp_dir / "config.json"
                 srsly.write_json(config_file, config_dict)
-                config = self.config_cls.from_pretrained(config_file)
+                config = self.config_cls.from_pretrained(config_file, **trf_config)
                 for x, x_bytes in tok_dict.items():
                     Path(temp_dir / x).write_bytes(x_bytes)
-                tokenizer = self.tokenizer_cls.from_pretrained(str(temp_dir.absolute()))
+                tokenizer = self.tokenizer_cls.from_pretrained(str(temp_dir.absolute()), **tok_config)
                 vocab_file_contents = None
                 if hasattr(tokenizer, "vocab_file"):
                     vocab_file_name = tokenizer.vocab_files_names["vocab_file"]


### PR DESCRIPTION
We're trying to give some parameters, such as use_fast and trsut_remote_code, to `AutoTokenizer.from_pretrained()` via kwargs in order to utilize custom tokenizers in spacy-transformers. In the current implementation of spacy-transformers, `HFShim.from_bytes()` does not apply kwargs to either `AutoConfig.from_pretrained()` or `AutoTokenizer.from_pretrained()`, while `huggingface_from_pretrained()` applies kwargs to both of them to create a transformer model.

https://github.com/huggingface/transformers/blob/dcb08b99f44919425f8ba9be9ddcc041af8ec25e/src/transformers/models/auto/tokenization_auto.py
https://github.com/huggingface/transformers/blob/dcb08b99f44919425f8ba9be9ddcc041af8ec25e/src/transformers/models/auto/configuration_auto.py#L679
https://github.com/explosion/spacy-transformers/blob/cab060701fe2bad0c9ae23a822249c9bebb56da7/spacy_transformers/layers/hf_shim.py#L98
https://github.com/explosion/spacy-transformers/blob/cab060701fe2bad0c9ae23a822249c9bebb56da7/spacy_transformers/layers/transformer_model.py#L256

In this pull request, we used `_init_tokenizer_config` and `_init_transformer_config` in msg passed from the deserializer as kwargs parameter of `from_pretrained()`.

Another possible approach is to write these kwargs in the `transformer/cfg`.