### PR TITLE
Add seen docs back to get_token_positions

### DIFF
--- a/spacy_transformers/align.py
+++ b/spacy_transformers/align.py
@@ -68,7 +68,11 @@ def _apply_empty_alignment(ops, align, X):
 
 def get_token_positions(spans: List[Span]) -> Dict[Token, int]:
     token_positions: Dict[Token, int] = {}
+    seen_docs = set()
     for span in spans:
+        if span.doc in seen_docs:
+            continue
+        seen_docs.add(span.doc)
         for token in span.doc:
             if token not in token_positions:
                 token_positions[token] = len(token_positions)


### PR DESCRIPTION
Matt took this out at some point (c507f8291), but it does make a noticeable difference in the speed of the alignment. For `en_core_web_trf` on GPU locally this speeds up the pipeline by ~300 WPS.

(I admit that I don't understand the cases where `for token in span` doesn't work.)