### PR TITLE
Serialize tokenizer use_fast setting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,3 +76,10 @@ jobs:
       pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.1.0-py3-none-any.whl --no-deps
       python -c "import spacy; nlp = spacy.load('en_core_web_trf'); doc = nlp('test')"
     displayName: 'Test backwards compatibility for v1.0 models'
+    condition: and(startsWith(variables['imageName'], 'ubuntu'), eq(variables['python.version'], '3.9'))
+
+  - script: |
+      pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.4.0-py3-none-any.whl --no-deps
+      python -c "import spacy; nlp = spacy.load('en_core_web_trf'); doc = nlp('test')"
+    displayName: 'Test backwards compatibility for v1.1 models'
+    condition: and(startsWith(variables['imageName'], 'ubuntu'), eq(variables['python.version'], '3.9'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
     condition: and(startsWith(variables['imageName'], 'ubuntu'), eq(variables['python.version'], '3.9'))
 
   - script: |
-      pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.4.0-py3-none-any.whl --no-deps
+      pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.4.0/en_core_web_trf-3.4.0-py3-none-any.whl --no-deps
       python -c "import spacy; nlp = spacy.load('en_core_web_trf'); doc = nlp('test')"
     displayName: 'Test backwards compatibility for v1.1 models'
     condition: and(startsWith(variables['imageName'], 'ubuntu'), eq(variables['python.version'], '3.9'))

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -64,7 +64,7 @@ class HFShim(PyTorchShim):
                     with open(vocab_file_path, "wb") as fileh:
                         fileh.write(hf_model.vocab_file_contents)
                     tokenizer.vocab_file = vocab_file_path
-                tok_dict["use_fast"] = tokenizer.is_fast
+                tok_dict["kwargs"] = {"use_fast": tokenizer.is_fast}
                 tokenizer.save_pretrained(str(temp_dir.absolute()))
                 for x in temp_dir.glob("**/*"):
                     if x.is_file():
@@ -94,10 +94,7 @@ class HFShim(PyTorchShim):
                 config_file = temp_dir / "config.json"
                 srsly.write_json(config_file, config_dict)
                 config = self.config_cls.from_pretrained(config_file)
-                tok_kwargs = {}
-                use_fast = tok_dict.pop("use_fast", None)
-                if use_fast is not None:
-                    tok_kwargs["use_fast"] = use_fast
+                tok_kwargs = tok_dict.pop("kwargs", {})
                 for x, x_bytes in tok_dict.items():
                     Path(temp_dir / x).write_bytes(x_bytes)
                 tokenizer = self.tokenizer_cls.from_pretrained(str(temp_dir.absolute()), **tok_kwargs)

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -64,6 +64,7 @@ class HFShim(PyTorchShim):
                     with open(vocab_file_path, "wb") as fileh:
                         fileh.write(hf_model.vocab_file_contents)
                     tokenizer.vocab_file = vocab_file_path
+                tok_dict["use_fast"] = tokenizer.is_fast
                 tokenizer.save_pretrained(str(temp_dir.absolute()))
                 for x in temp_dir.glob("**/*"):
                     if x.is_file():
@@ -93,9 +94,13 @@ class HFShim(PyTorchShim):
                 config_file = temp_dir / "config.json"
                 srsly.write_json(config_file, config_dict)
                 config = self.config_cls.from_pretrained(config_file)
+                tok_kwargs = {}
+                use_fast = tok_dict.pop("use_fast", None)
+                if use_fast is not None:
+                    tok_kwargs["use_fast"] = use_fast
                 for x, x_bytes in tok_dict.items():
                     Path(temp_dir / x).write_bytes(x_bytes)
-                tokenizer = self.tokenizer_cls.from_pretrained(str(temp_dir.absolute()))
+                tokenizer = self.tokenizer_cls.from_pretrained(str(temp_dir.absolute()), **tok_kwargs)
                 vocab_file_contents = None
                 if hasattr(tokenizer, "vocab_file"):
                     vocab_file_name = tokenizer.vocab_files_names["vocab_file"]

--- a/spacy_transformers/tests/test_model_wrapper.py
+++ b/spacy_transformers/tests/test_model_wrapper.py
@@ -47,11 +47,18 @@ def trf_model(name, output_attentions, output_hidden_states):
                 "output_hidden_states": output_hidden_states,
             },
         )
+
     else:
+        # test slow tokenizers with distilbert-base-uncased (parameterizing
+        # for all models blows up the memory usage during the test suite)
+        if name == "distilbert-base-uncased":
+            use_fast = False
+        else:
+            use_fast = True
         model = TransformerModel(
             name,
             get_doc_spans,
-            {"use_fast": True},
+            {"use_fast": use_fast},
             {
                 "output_attentions": output_attentions,
                 "output_hidden_states": output_hidden_states,
@@ -63,6 +70,10 @@ def trf_model(name, output_attentions, output_hidden_states):
 
 def test_model_init(name, trf_model):
     assert isinstance(trf_model, Model)
+    if name == "distilbert-base-uncased":
+        assert not trf_model.tokenizer.is_fast
+    else:
+        assert trf_model.tokenizer.is_fast
 
 
 def test_model_predict(docs, trf_model):


### PR DESCRIPTION
Preserve `tokenizer.is_fast` as `use_fast` in `HFShim` in order to be able to restore the same slow/fast tokenizer settings.

This will be necessary when fast tokenizers switch to offset alignments from wordpiece string alignments.