### PR TITLE
Remove examples validation for Transformer.initialize

### DIFF
--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -5,7 +5,7 @@ from spacy.pipeline.trainable_pipe import TrainablePipe
 from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
-from spacy.training import Example, validate_examples, validate_get_examples
+from spacy.training import Example, validate_examples
 from spacy import util, Errors
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -350,7 +350,6 @@ class Transformer(TrainablePipe):
 
         DOCS: https://spacy.io/api/transformer#initialize
         """
-        validate_get_examples(get_examples, "Transformer.initialize")
         docs = [Doc(Vocab(), words=["hello"])]
         self.model.initialize(X=docs)
         if nlp is not None:


### PR DESCRIPTION
`get_examples` is not used by the `transformer` initialization so remove
the check that prevents you from initializing just a `transformer` with:

```
transformer.initialize(lambda: [])
```