### PR TITLE
Revert "bump github action versions to deal with deprecation warnings"

### DIFF
--- a/.github/workflows/explosionbot.yml
+++ b/.github/workflows/explosionbot.yml
@@ -14,8 +14,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
       - name: Install and run explosion-bot
         run: |
           pip install git+https://${{ secrets.EXPLOSIONBOT_TOKEN }}@github.com/explosion/explosion-bot


### PR DESCRIPTION
This reverts commit 9acb284a0d22323092111177dca71b9906f345f1.

Tests succeeded on the PR #347, but in master the builds are failing with unusual errors. This PR is to check if reverting the changes makes the builds succeed again.

In some detail, the errors included OOM, abort signal (possibly from OOM?), and what appears to be a filesystem-related failure on Windows. One re-run resolved the OOM issue but not the others.

It seems implausible the changes caused these errors, especially as they don't seem related to each other, but this should help check what's up.