### PR TITLE
Add test for textcat CNN issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ torch>=1.6.0
 srsly>=2.4.0,<3.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"
 spacy-alignments>=0.7.2,<1.0.0
+# TODO for PR, remove before merge
+git+https://github.com/polm/thinc.git@fix/resizable-initialized-check
 # Development dependencies
 cython>=0.25
 pytest>=5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ torch>=1.6.0
 srsly>=2.4.0,<3.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"
 spacy-alignments>=0.7.2,<1.0.0
-# TODO for PR, remove before merge
-git+https://github.com/polm/thinc.git@fix/resizable-initialized-check
 # Development dependencies
 cython>=0.25
 pytest>=5.2.0

--- a/spacy_transformers/tests/test_textcatcnn.py
+++ b/spacy_transformers/tests/test_textcatcnn.py
@@ -1,0 +1,51 @@
+from spacy.training.example import Example
+from spacy import util
+from thinc.api import Model, Config
+
+# fmt: off
+cfg_string = """
+    [nlp]
+    lang = "en"
+    pipeline = ["textcat"]
+
+    [components]
+
+    [components.textcat]
+    factory = "textcat"
+
+    [components.textcat.model]
+    @architectures = "spacy.TextCatCNN.v2"
+    nO = null
+    exclusive_classes = false
+
+    [components.textcat.model.tok2vec]
+    @architectures = "spacy-transformers.Tok2VecTransformer.v1"
+    name = "roberta-base"
+    tokenizer_config = {"use_fast": false}
+    grad_factor = 1.0
+
+    [components.textcat.model.tok2vec.get_spans]
+    @span_getters = "spacy-transformers.strided_spans.v1"
+    window = 256
+    stride = 256
+
+    [components.textcat.model.tok2vec.pooling]
+    @layers = "reduce_mean.v1"
+    """
+# fmt: on
+
+def test_textcatcnn():
+    orig_config = Config().from_str(cfg_string)
+    nlp = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
+    assert nlp.pipe_names == ["textcat"]
+
+    textcat = nlp.get_pipe("textcat")
+    
+    train_examples = []
+    doc = nlp.make_doc("ok")
+    doc.cats["X"] = 1.0
+    doc.cats["Y"] = 0.0
+    train_examples.append(Example(doc, doc))
+
+    nlp.initialize(lambda: train_examples)
+

--- a/spacy_transformers/tests/test_textcatcnn.py
+++ b/spacy_transformers/tests/test_textcatcnn.py
@@ -41,6 +41,7 @@ def test_textcatcnn():
     assert nlp.pipe_names == ["textcat"]
 
     textcat = nlp.get_pipe("textcat")
+    assert textcat.is_resizable is True
 
     train_examples = []
     doc = nlp.make_doc("ok")

--- a/spacy_transformers/tests/test_textcatcnn.py
+++ b/spacy_transformers/tests/test_textcatcnn.py
@@ -34,13 +34,14 @@ cfg_string = """
     """
 # fmt: on
 
+
 def test_textcatcnn():
     orig_config = Config().from_str(cfg_string)
     nlp = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
     assert nlp.pipe_names == ["textcat"]
 
     textcat = nlp.get_pipe("textcat")
-    
+
     train_examples = []
     doc = nlp.make_doc("ok")
     doc.cats["X"] = 1.0
@@ -48,4 +49,3 @@ def test_textcatcnn():
     train_examples.append(Example(doc, doc))
 
     nlp.initialize(lambda: train_examples)
-

--- a/spacy_transformers/tests/test_textcatcnn.py
+++ b/spacy_transformers/tests/test_textcatcnn.py
@@ -1,5 +1,9 @@
+import pytest
+from packaging.version import Version
+
 from spacy.training.example import Example
 from spacy import util
+import thinc
 from thinc.api import Model, Config
 
 # fmt: off
@@ -35,6 +39,11 @@ cfg_string = """
 # fmt: on
 
 
+# TODO: remove skip after requiring spacy>=3.5.1 or at the very latest, after
+# dropping python 3.7 switch to importlib.metadata.version("thinc")
+@pytest.mark.skipif(
+    Version(thinc.__version__) < Version("8.1.8"), reason="Requires thinc>=8.1.8"
+)
 def test_textcatcnn():
     orig_config = Config().from_str(cfg_string)
     nlp = util.load_model_from_config(orig_config, auto_fill=True, validate=True)


### PR DESCRIPTION
This is a test demonstrating the issue in https://github.com/explosion/spaCy/issues/11968. A potential fix is being worked on in https://github.com/explosion/thinc/pull/820. 

In its current condition, the test just creates a pipeline with textcat and transformer, creates a minimal doc and calls `nlp.initialize`. As described in the spaCy issue, that fails with this error:

```
ValueError: Cannot get dimension 'nI' for model 'linear': value unset
```

This will be left in draft until the fix is clarified.