### PR TITLE
Update for python 3.11, update CI for python 3.6/3.11 and to remove numpy/torch workarounds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,9 @@ jobs:
       Python310Mac:
         imageName: 'macos-latest'
         python.version: '3.10'
+      Python311Windows:
+        imageName: 'windows-latest'
+        python.version: '3.11'
     maxParallel: 4
   pool:
     vmImage: $(imageName)
@@ -77,11 +80,6 @@ jobs:
       pip install "torch==1.8.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
     displayName: 'Install oldest supported torch for python 3.6'
     condition: eq(variables['python.version'], '3.6')
-
-  - script: |
-      pip install "torch<1.13.0+cpu" --extra-index-url https://download.pytorch.org/whl/cpu
-    displayName: 'Install newest working torch for python 3.7+'
-    condition: ne(variables['python.version'], '3.6')
 
   - bash: |
       SDIST=$(python -c "import os;print(os.listdir('./dist')[0])" 2>&1)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
   strategy:
     matrix:
       Python36Linux:
-        imageName: 'ubuntu-latest'
+        imageName: 'ubuntu-20.04'
         python.version: '3.6'
       Python37Mac:
         imageName: 'macos-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,8 +31,8 @@ jobs:
       Python310Mac:
         imageName: 'macos-latest'
         python.version: '3.10'
-      Python311Windows:
-        imageName: 'windows-latest'
+      Python311Linux:
+        imageName: 'ubuntu-latest'
         python.version: '3.11'
     maxParallel: 4
   pool:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = false


### PR DESCRIPTION
Add python 3.11 support, remove workarounds in CI for `torch~=1.13.0` and and `numpy>=1.22,<1.24`, update CI for python 3.6.