### PR TITLE
Correct and clarify the handling of empty/zero-length `Doc`s during training and inference

### DIFF
--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -48,7 +48,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
                 outputs.append(output)
                 backprops.append((get_d_dst, get_d_src))  # type: ignore
         else:
-            # This can happen during prediciton/training for zero-length documents. Since zero-length docs
+            # This can happen during prediction/training for zero-length documents. Since zero-length docs
             # are implicitly ignored in the span generation stage, the transformer model does not return any
             # predictions for them and subsequently, FullTransformerBatch.split_by_doc() generates an empty
             # TransformerData.

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -23,15 +23,15 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
     outputs = []
     backprops = []
 
-    # Cache the width of the model outputs from a non-empty output, if possible.
-    width = 0
+    # If possible, cache the width for allocating zero-length tensors.
+    output_width = 0
     for trf_data in trf_datas:
         if "last_hidden_state" in trf_data.model_output:
             last_hidden_state = cast(
                 BaseModelOutput, trf_data.model_output
             ).last_hidden_state
             assert len(last_hidden_state.shape) == 3  # [batch, seq_len, width]
-            width = last_hidden_state.shape[2]
+            output_width = last_hidden_state.shape[2]
             break
 
     for trf_data in trf_datas:
@@ -41,25 +41,22 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
                 # This can happen during prediction/initialization if the transformer pipe was disabled/not executed and one of the inputs
                 # was of length zero. This causes the listenener to generate a zero-sized (in the sequence length dim) TransformerData
                 # output and pass it downstream.
-                #
-                # We also don't have to ensure that the backprops list stays in sync with the outputs as zero-length documents
-                # are filtered out very early in the corpus generation stage of the training loop.
-                assert not is_train
-                outputs.append(model.ops.alloc2f(0, width))
+                outputs.append(model.ops.alloc2f(0, output_width))
+                backprops.append((None, None))
             else:
                 # This is the general case for non-zero length documents.
                 src = model.ops.reshape2f(tensor_t_i, -1, trf_data.width)  # type: ignore
                 dst, get_d_src = apply_alignment(model.ops, trf_data.align, src)
                 output, get_d_dst = pooling(dst, is_train)
                 outputs.append(output)
-                backprops.append((get_d_dst, get_d_src))
+                backprops.append((get_d_dst, get_d_src))  # type: ignore
         else:
-            # This can happen during prediciton for zero-length documents. Since zero-length docs
+            # This can happen during prediciton/training for zero-length documents. Since zero-length docs
             # are implicitly ignored in the span generation stage, the transformer model does not return any
             # predictions for them and subsequently, FullTransformerBatch.split_by_doc() generates an empty
             # TransformerData.
-            assert not is_train
-            outputs.append(model.ops.alloc2f(0, width))
+            outputs.append(model.ops.alloc2f(0, output_width))
+            backprops.append((None, None))
 
     def backprop_trf_to_tensor(d_outputs: List[Floats2d]) -> List[TransformerData]:
         d_trf_datas = []
@@ -67,14 +64,23 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
         assert all_equal(len(x) for x in to_zip)  # type: ignore
         zipped = zip(*to_zip)
         for trf_data, d_output, (get_d_dst, get_d_src) in zipped:
+            if "last_hidden_state" not in trf_data.model_output:
+                # This gradient belongs to a zero-length doc and must be ignored as it doesn't have a corresponding
+                # output from the transformer model (due to empty documents being skipped during the span generation
+                # stage in the forward pass).
+                assert len(d_output) == 0
+                assert get_d_src is None
+                assert get_d_dst is None
+                continue
+
             d_model_output = ModelOutput(
                 last_hidden_state=model.ops.alloc(
                     trf_data.model_output.last_hidden_state.shape,  # type: ignore
                     dtype=trf_data.model_output.last_hidden_state.dtype,  # type: ignore
                 )
             )
-            d_dst = get_d_dst(d_output)
-            d_src = get_d_src(d_dst)
+            d_dst = get_d_dst(d_output)  # type: ignore
+            d_src = get_d_src(d_dst)  # type: ignore
             d_src *= grad_factor
             d_model_output["last_hidden_state"] = d_src.reshape(
                 cast(BaseModelOutput, trf_data.model_output).last_hidden_state.shape

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -27,7 +27,9 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
     width = 0
     for trf_data in trf_datas:
         if "last_hidden_state" in trf_data.model_output:
-            last_hidden_state = trf_data.model_output.last_hidden_state
+            last_hidden_state = cast(
+                BaseModelOutput, trf_data.model_output
+            ).last_hidden_state
             assert len(last_hidden_state.shape) == 3  # [batch, seq_len, width]
             width = last_hidden_state.shape[2]
             break
@@ -62,7 +64,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
     def backprop_trf_to_tensor(d_outputs: List[Floats2d]) -> List[TransformerData]:
         d_trf_datas = []
         to_zip = (trf_datas, d_outputs, backprops)
-        assert all_equal(len(x) for x in to_zip)
+        assert all_equal(len(x) for x in to_zip)  # type: ignore
         zipped = zip(*to_zip)
         for trf_data, d_output, (get_d_dst, get_d_src) in zipped:
             d_model_output = ModelOutput(

--- a/spacy_transformers/tests/regression/test_spacy_issue7029.py
+++ b/spacy_transformers/tests/regression/test_spacy_issue7029.py
@@ -33,13 +33,13 @@ grad_factor = 1.0
 
 TRAIN_DATA = [
     ("I like green eggs", {"tags": ["N", "V", "J", "N"]}),
+    ("", {}),
     ("Eat blue ham", {"tags": ["V", "J", "N"]}),
 ]
 
 
 def test_empty_doc():
-    """Test that an empty document gets processed correctly
-    """
+    """Test that an empty document gets processed correctly"""
     nlp = English.from_config(load_config_from_str(CONFIG))
     train_examples = []
     for t in TRAIN_DATA:

--- a/spacy_transformers/tests/test_pipeline_component.py
+++ b/spacy_transformers/tests/test_pipeline_component.py
@@ -301,6 +301,9 @@ def test_transformer_pipeline_empty():
     nlp.update([empty_train_example], sgd=optimizer, losses=losses)
     train_examples.append(empty_train_example)
     nlp.update(train_examples, sgd=optimizer, losses=losses)
+    # Interleave an empty doc between non-empty ones
+    train_examples.insert(1, Example.from_dict(nlp.make_doc(""), {}))
+    nlp.update(train_examples, sgd=optimizer, losses=losses)
 
     # predict empty doc
     doc = nlp("")


### PR DESCRIPTION
## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
This PR addresses two issues:
- When zero-length inputs passed to the transformer pipe, the outputs yielded by an attached listener has the wrong shape in the representation width dimension. This is more of a question of correctness than a practical concern due to the lack of tokens in such `Doc`s, but we explicitly clarify why we use zero-width outputs.
- Backprop callbacks and gradients were not correctly aligned to their corresponding model outputs (outputs from the transformer pipe) when empty documents occurred in the middle of a training batch. The existing tests for this corner-case were inadvertently passing due to the behaviour of `zip`, i.e., the test always added the empty document to the end of the batch, and the subsequent `zip` operation would implicitly skip the last backprop/gradient due to the latter list being shorter than the list of model outputs.

It also adds comments about the pre-conditions to clarify the circumstances under which zero-length inputs are passed to the model.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Bug Fix

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
