### PR TITLE
Fix compilation with recent Cython 3.x versions

### DIFF
--- a/spacy_transformers/align.pyx
+++ b/spacy_transformers/align.pyx
@@ -239,7 +239,7 @@ def get_span2wp_from_offset_mapping(span, wp_char_offsets):
     return result
 
 
-cdef void _get_span2wp_alignment(
+cdef int _get_span2wp_alignment(
         vector[unordered_set_uint32_t_ptr]* alignment,
         int32_t[::1] char_to_sp_token,
         int char_to_sp_token_length,
@@ -262,3 +262,4 @@ cdef void _get_span2wp_alignment(
                 deref(alignment.at(token_i)).insert(wp_j)
             char_idx += 1
         wp_j += 1
+    return 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Recent versions of Cython 3.x refuse to compile the `_get_span2wp_alignment` function because it always requires acquiring the GIL to check if any exceptions are raised. Change the function signature to return an `int`, so that `-1` can be used to signal that an exception occured.

It's not safe to qualify the function `noexcept`, since some calls can throw an exception.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bugfix

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
