### PR TITLE
Migrate to safe-tensors and pyright

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.12"]
         include:
-          - os: macos-13
-            python_version: "3.10"
+          - os: macos-latest
+            python_version: "3.11"
           - os: windows-latest
             python_version: "3.11"
           - os: ubuntu-latest
-            python_version: "3.12"
-          - os: macos-13
             python_version: "3.12"
           - os: windows-latest
             python_version: "3.12"
@@ -61,7 +59,7 @@ jobs:
           python -m build --sdist
 
       - name: Run pyright
-        if: env.RUN_PYRIGHT == 'true' && matrix.python_version != '3.6'
+        if: env.RUN_PYRIGHT == 'true'
         shell: bash
         run: |
           python -m pyright $MODULE_NAME
@@ -77,8 +75,7 @@ jobs:
           python -m pip freeze --exclude pywin32 --exclude torch > installed.txt
           python -m pip uninstall -y -r installed.txt
 
-      - name: Install newest torch for python 3.7+
-        if: matrix.python_version != '3.6'
+      - name: Install newest torch
         run: |
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu --force-reinstall
 
@@ -92,8 +89,5 @@ jobs:
         shell: bash
         run: |
           python -m pip install -r requirements.txt --force-reinstall
-          # The version of pytorch being used here requires numpy v2, but because of the way we're doing the
-          # requirements installation here it's not being resolved that way. So just install numpy 1 here.
-          python -m pip install "numpy<2"
           python -m pytest --pyargs $MODULE_NAME --cov=$MODULE_NAME
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   MODULE_NAME: "spacy_transformers"
-  RUN_MYPY: "true"
+  RUN_PYRIGHT: "true"
 
 jobs:
   tests:
@@ -60,11 +60,11 @@ jobs:
         run: |
           python -m build --sdist
 
-      - name: Run mypy
-        if: env.RUN_MYPY == 'true' && matrix.python_version != '3.6'
+      - name: Run pyright
+        if: env.RUN_PYRIGHT == 'true' && matrix.python_version != '3.6'
         shell: bash
         run: |
-          python -m mypy $MODULE_NAME
+          python -m pyright $MODULE_NAME
 
       - name: Delete source directory
         shell: bash

--- a/bin/repackage_model.py
+++ b/bin/repackage_model.py
@@ -1,0 +1,96 @@
+"""Repackage en_core_web_trf to work with spacy-transformers 1.4+ and spacy 3.8+.
+
+Loads the installed en_core_web_trf model, converts serialized weights from
+torch pickle to safetensors format, and writes a new spaCy model package
+named en_core_web_hftrf.
+"""
+import json
+import shutil
+from pathlib import Path
+
+import spacy
+from spacy.util import get_package_path
+
+SRC_VERSION = "3.6.1"
+NEW_VERSION = "3.8.1"
+PKG_NAME = "en_core_web_hftrf"
+META_NAME = "core_web_hftrf"
+SPACY_COMPAT = ">=3.8.0,<3.9.0"
+SPACY_TRF_COMPAT = ">=1.4.0,<1.5.0"
+
+src_path = get_package_path("en_core_web_trf")
+model_dir = src_path / f"en_core_web_trf-{SRC_VERSION}"
+
+# Layout: out_root/setup.cfg, out_root/en_core_web_hftrf/__init__.py, etc.
+out_root = Path("dist") / f"{PKG_NAME}-{NEW_VERSION}"
+pkg_dir = out_root / PKG_NAME
+data_dir = pkg_dir / f"{PKG_NAME}-{NEW_VERSION}"
+
+if out_root.exists():
+    shutil.rmtree(out_root)
+
+# Copy the full model directory into the package
+shutil.copytree(model_dir, data_dir)
+
+# --- Convert transformer weights to safetensors ---
+print("Loading model to convert transformer weights...")
+nlp = spacy.load(model_dir)
+trf = nlp.get_pipe("transformer")
+model_bytes = trf.model.to_bytes()
+print(f"  Serialized transformer model: {len(model_bytes)} bytes")
+(data_dir / "transformer" / "model").write_bytes(model_bytes)
+
+# --- Update meta.json ---
+meta = json.loads((data_dir / "meta.json").read_text())
+meta["name"] = META_NAME
+meta["version"] = NEW_VERSION
+meta["spacy_version"] = SPACY_COMPAT
+meta["requirements"] = [f"spacy-transformers{SPACY_TRF_COMPAT}"]
+(data_dir / "meta.json").write_text(json.dumps(meta, indent=2))
+
+# --- Write package __init__.py ---
+init_py = f'''"""{PKG_NAME} model, repackaged for spacy-transformers {SPACY_TRF_COMPAT}."""
+from pathlib import Path
+from spacy.util import load_model_from_init_py, get_model_meta
+
+__version__ = get_model_meta(Path(__file__).parent / "{PKG_NAME}-{NEW_VERSION}")["version"]
+
+def load(**overrides):
+    return load_model_from_init_py(__file__, **overrides)
+'''
+(pkg_dir / "__init__.py").write_text(init_py)
+
+# spacy.load looks for meta.json next to __init__.py
+shutil.copy(data_dir / "meta.json", pkg_dir / "meta.json")
+
+# --- Write build files at project root ---
+setup_cfg = f"""[metadata]
+name = {PKG_NAME}
+version = {NEW_VERSION}
+description = English transformer pipeline (roberta-base), repackaged for spacy-transformers 1.4+
+license = MIT
+
+[options]
+zip_safe = false
+include_package_data = true
+packages = {PKG_NAME}
+python_requires = >=3.11
+install_requires =
+    spacy{SPACY_COMPAT}
+    spacy-transformers{SPACY_TRF_COMPAT}
+"""
+(out_root / "setup.cfg").write_text(setup_cfg)
+
+pyproject_toml = """[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+"""
+(out_root / "pyproject.toml").write_text(pyproject_toml)
+
+manifest = f"""recursive-include {PKG_NAME} *
+"""
+(out_root / "MANIFEST.in").write_text(manifest)
+
+print(f"\nRepackaged model written to: {out_root}")
+print(f"To build a wheel: cd {out_root} && python -m build --wheel")
+print(f"To load: spacy.load('{PKG_NAME}')")

--- a/bin/smoketest.py
+++ b/bin/smoketest.py
@@ -1,0 +1,10 @@
+"""Smoke test: load en_core_web_hftrf and run NER end-to-end."""
+import spacy
+
+nlp = spacy.load("en_core_web_hftrf")
+doc = nlp("Apple is looking at buying U.K. startup for $1 billion")
+assert len(doc) > 0
+assert len(doc.ents) > 0
+print(f"Entities: {[(ent.text, ent.label_) for ent in doc.ents]}")
+print(f"Tokens: {len(doc)}")
+print("Smoke test passed.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build = "*"
-skip = "pp* cp36* cp37* cp38* cp39* cp3??t-* *cp310-win_arm64"
+skip = "pp* cp36* cp37* cp38* cp39* cp310* cp3??t-*"
 test-skip = ""
 
 archs = ["native"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["spacy_transformers"],
+  "exclude": ["spacy_transformers/tests"],
+  "typeCheckingMode": "basic",
+  "reportMissingImports": false,
+  "reportMissingModuleSource": false,
+  "pythonVersion": "3.10"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,4 @@ spacy-alignments>=0.7.2,<1.0.0
 cython>=0.25
 pytest>=5.2.0
 pytest-cov>=2.7.0,<5.0.0
-mypy>=1.0.0,<1.6.0; platform_machine!='aarch64' and python_version >= "3.7"
-types-contextvars>=0.1.2; python_version < "3.7"
-types-dataclasses>=0.1.3; python_version < "3.7"
+pyright>=1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
@@ -28,15 +27,14 @@ classifiers =
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=3.10,<4.0
+python_requires = >=3.11,<4.0
 install_requires =
     spacy>=3.5.0,<4.1.0
-    numpy>=1.15.0; python_version < "3.9"
-    numpy>=1.19.0; python_version >= "3.9"
+    numpy>=1.19.0
     transformers>=3.4.0,< 4.53.3
     torch>=1.8.0
     srsly>=2.4.0,<3.0.0
-    dataclasses>=0.6,<1.0; python_version < "3.7"
+    safetensors>=0.4.0
     spacy-alignments>=0.7.2,<1.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,11 +91,6 @@ exclude =
     .git,
     __pycache__,
 
-[mypy]
-ignore_missing_imports = True
-no_implicit_optional = True
-plugins = pydantic.mypy, thinc.mypy
-
 [coverage:run]
 
 [coverage:report]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.11,<4.0
 install_requires =
     spacy>=3.5.0,<4.1.0
     numpy>=1.19.0
-    transformers>=3.4.0,< 4.53.3
+    transformers>=4.45.0
     torch>=1.8.0
     srsly>=2.4.0,<3.0.0
     safetensors>=0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 1.4.0
+version = 2.0.0
 description = spaCy pipelines for pre-trained BERT and other transformers
 url = https://spacy.io
 author = Explosion

--- a/spacy_transformers/data_classes.py
+++ b/spacy_transformers/data_classes.py
@@ -2,8 +2,8 @@ from typing import Optional, List, Dict, Any, Union, Tuple, cast
 from dataclasses import dataclass, field
 import torch
 import numpy
-from transformers.tokenization_utils import BatchEncoding
-from transformers.file_utils import ModelOutput
+from transformers.tokenization_utils_base import BatchEncoding
+from transformers.utils.generic import ModelOutput
 from transformers.modeling_outputs import BaseModelOutput
 from thinc.types import Ragged, Floats2d, Floats3d, FloatsXd, Ints1d, Ints2d
 from thinc.api import NumpyOps, get_array_module, xp2torch, torch2xp
@@ -93,20 +93,21 @@ class WordpieceBatch:
     @classmethod
     def from_batch_encoding(cls, token_data: BatchEncoding) -> "WordpieceBatch":
         assert isinstance(token_data, BatchEncoding) or isinstance(token_data, dict)
-        pad_token = token_data.get("pad_token", "[PAD]")
+        pad_token: Any = token_data.get("pad_token", "[PAD]")
+        input_texts: Any = token_data["input_texts"]
         lengths = [
             len([tok for tok in tokens if tok != pad_token])
-            for tokens in token_data["input_texts"]
+            for tokens in input_texts
         ]
 
         # The following tensors are intentionally allocated on the CPU to reduce
         # host-to-device copies.
         numpy_ops = NumpyOps()
-        input_ids = token_data["input_ids"]
-        token_type_ids = token_data.get("token_type_ids")
+        input_ids: Any = token_data["input_ids"]
+        token_type_ids: Any = token_data.get("token_type_ids")
 
         return cls(
-            strings=token_data["input_texts"],
+            strings=input_texts,
             input_ids=numpy_ops.asarray(input_ids, dtype=input_ids.dtype),
             attention_mask=numpy_ops.asarray2f(token_data["attention_mask"]),
             lengths=lengths,
@@ -198,7 +199,9 @@ class TransformerData:
     @property
     def width(self) -> int:
         if "last_hidden_state" in self.model_output:
-            return cast(BaseModelOutput, self.model_output).last_hidden_state.shape[-1]
+            last_hidden = cast(BaseModelOutput, self.model_output).last_hidden_state
+            assert last_hidden is not None
+            return last_hidden.shape[-1]
         else:
             raise ValueError("Cannot find last hidden state")
 
@@ -219,7 +222,7 @@ class TransformerData:
         return srsly.msgpack_dumps(self.to_dict())
 
     def from_bytes(self, byte_string: bytes) -> "TransformerData":
-        msg = srsly.msgpack_loads(byte_string)
+        msg: Any = srsly.msgpack_loads(byte_string)
         self.from_dict(msg)
         return self
 
@@ -312,7 +315,7 @@ class FullTransformerBatch:
         # construct a dummy ModelOutput with the tensor values
         model_output = ModelOutput()
         for i, x in enumerate(transpose_list(arrays)):
-            model_output[f"output_{i}"] = xp2torch(xp.vstack(x))
+            model_output[f"output_{i}"] = xp2torch(cast(FloatsXd, xp.vstack(x)))
         return FullTransformerBatch(
             spans=self.spans,
             wordpieces=self.wordpieces,
@@ -331,7 +334,9 @@ class FullTransformerBatch:
 
         # Convert all outputs to XP arrays.
         xp_model_output = ModelOutput()
-        last_hidden_state = cast(BaseModelOutput, self.model_output).last_hidden_state
+        _lhs = cast(BaseModelOutput, self.model_output).last_hidden_state
+        assert _lhs is not None
+        last_hidden_state = _lhs
         for key, output in self.model_output.items():
             if isinstance(output, torch.Tensor):
                 xp_model_output[key] = torch2xp(output)

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -1,9 +1,7 @@
 from typing import Any, Dict, cast
-from io import BytesIO
 from pathlib import Path
 import srsly
-import torch
-import warnings
+from safetensors.torch import save, load as safetensors_load
 from thinc.api import get_torch_default_device
 from spacy.util import SimpleFrozenDict
 
@@ -70,10 +68,7 @@ class HFShim(PyTorchShim):
                 for x in temp_dir.glob("**/*"):
                     if x.is_file():
                         tok_dict[x.name] = x.read_bytes()
-            filelike = BytesIO()
-            torch.save(self._model.state_dict(), filelike)
-            filelike.seek(0)
-            weights_bytes = filelike.getvalue()
+            weights_bytes = save(self._model.state_dict())
         else:
             tok_cfg = hf_model._init_tokenizer_config
             trf_cfg = hf_model._init_transformer_config
@@ -117,27 +112,9 @@ class HFShim(PyTorchShim):
                 SimpleFrozenDict(),
             )
             self._model = transformer
-            filelike = BytesIO(msg["state"])
-            filelike.seek(0)
             device = get_torch_default_device()
-            try:
-                self._model.load_state_dict(torch.load(filelike, map_location=device))
-            except RuntimeError:
-                warn_msg = (
-                    "Error loading saved torch state_dict with strict=True, "
-                    "likely due to differences between 'transformers' "
-                    "versions. Attempting to load with strict=False as a "
-                    "fallback...\n\n"
-                    "If you see errors or degraded performance, download a "
-                    "newer compatible model or retrain your custom model with "
-                    "the current 'transformers' and 'spacy-transformers' "
-                    "versions. For more details and available updates, run: "
-                    "python -m spacy validate"
-                )
-                warnings.warn(warn_msg)
-                filelike.seek(0)
-                b = torch.load(filelike, map_location=device)
-                self._model.load_state_dict(b, strict=False)
+            state_dict = safetensors_load(msg["state"])
+            self._model.load_state_dict(state_dict)
             self._model.to(device)
         else:
             self._hfmodel = HFObjects(

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, cast
+from io import BytesIO
 from pathlib import Path
 import srsly
+import torch
 from safetensors.torch import save, load as safetensors_load
 from thinc.api import get_torch_default_device
 from spacy.util import SimpleFrozenDict
@@ -113,7 +115,20 @@ class HFShim(PyTorchShim):
             )
             self._model = transformer
             device = get_torch_default_device()
-            state_dict = safetensors_load(msg["state"])
+            state_bytes = msg["state"]
+            if _is_safetensors(state_bytes):
+                state_dict = safetensors_load(state_bytes)
+            else:
+                state_dict = torch.load(
+                    BytesIO(state_bytes),
+                    map_location=device,
+                    weights_only=True,
+                )
+            # Filter out keys not present in the model to handle
+            # cross-version differences (e.g. position_ids added/removed
+            # between transformers versions).
+            model_keys = set(self._model.state_dict().keys())
+            state_dict = {k: v for k, v in state_dict.items() if k in model_keys}
             self._model.load_state_dict(state_dict)
             self._model.to(device)
         else:
@@ -125,3 +140,10 @@ class HFShim(PyTorchShim):
                 msg["_init_transformer_config"],
             )
         return self
+
+
+def _is_safetensors(data: bytes) -> bool:
+    """Check whether bytes are in safetensors format (vs torch pickle)."""
+    # Safetensors starts with a u64 LE header size; torch.save starts with
+    # the PK zip magic bytes.
+    return len(data) >= 8 and data[:2] != b"PK"

--- a/spacy_transformers/layers/hf_shim.py
+++ b/spacy_transformers/layers/hf_shim.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, cast
 from io import BytesIO
 from pathlib import Path
 import srsly
@@ -87,7 +87,7 @@ class HFShim(PyTorchShim):
         return srsly.msgpack_dumps(msg)
 
     def from_bytes(self, bytes_data):
-        msg = srsly.msgpack_loads(bytes_data)
+        msg: Dict[str, Any] = cast(Dict[str, Any], srsly.msgpack_loads(bytes_data))
         config_dict = msg["config"]
         tok_dict = msg["tokenizer"]
         if config_dict:

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -277,7 +277,9 @@ def huggingface_from_pretrained(
             vocab_file_contents = fileh.read()
     trf_config["return_dict"] = True
     config = config_cls.from_pretrained(str_path, **trf_config)
-    transformer = model_cls.from_pretrained(str_path, config=config)
+    transformer = model_cls.from_pretrained(
+        str_path, config=config, weights_only=False
+    )
     torch_device = get_torch_default_device()
     transformer.to(torch_device)
     return HFObjects(tokenizer, transformer, vocab_file_contents)

--- a/spacy_transformers/layers/transformer_model.py
+++ b/spacy_transformers/layers/transformer_model.py
@@ -1,10 +1,10 @@
-from typing import List, Tuple, Callable, Union, Dict
+from typing import Any, List, Tuple, Callable, Union, Dict, cast as typing_cast
 import copy
 from pathlib import Path
-from transformers.file_utils import ModelOutput
+from transformers.utils.generic import ModelOutput
 from transformers import AutoConfig, AutoModel, AutoTokenizer
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
-from transformers.tokenization_utils import BatchEncoding
+from transformers.tokenization_utils_base import BatchEncoding
 
 from spacy.tokens import Doc
 from thinc.api import Model, get_torch_default_device, xp2torch
@@ -18,6 +18,7 @@ from ..util import log_gpu_memory, log_batch_size
 from ..layers._util import replace_listener, replace_listener_cfg
 from ..truncate import truncate_oversize_splits
 from ..align import get_alignment, get_alignment_via_offset_mapping
+from .hf_shim import HFShim
 from .hf_wrapper import HFWrapper
 
 
@@ -66,21 +67,24 @@ class TransformerModel(Model):
             },
         )
 
+    def _get_shim(self) -> HFShim:
+        return typing_cast(HFShim, self.layers[0].shims[0])
+
     @property
     def tokenizer(self):
-        return self.layers[0].shims[0]._hfmodel.tokenizer
+        return self._get_shim()._hfmodel.tokenizer
 
     @property
     def transformer(self):
-        return self.layers[0].shims[0]._hfmodel.transformer
+        return self._get_shim()._hfmodel.transformer
 
     @property
     def _init_tokenizer_config(self):
-        return self.layers[0].shims[0]._hfmodel._init_tokenizer_config
+        return self._get_shim()._hfmodel._init_tokenizer_config
 
     @property
     def _init_transformer_config(self):
-        return self.layers[0].shims[0]._hfmodel._init_transformer_config
+        return self._get_shim()._hfmodel._init_transformer_config
 
     def copy(self):
         """
@@ -92,8 +96,8 @@ class TransformerModel(Model):
         params = {}
         for name in self.param_names:
             params[name] = self.get_param(name) if self.has_param(name) else None
-        copied.params = copy.deepcopy(params)
-        copied.dims = copy.deepcopy(self._dims)
+        copied.params = copy.deepcopy(params)  # type: ignore[attr-defined]
+        copied.dims = copy.deepcopy(self._dims)  # type: ignore[attr-defined]
         copied.layers[0] = copy.deepcopy(self.layers[0])
         for name in self.grad_names:
             copied.set_grad(name, self.get_grad(name).copy())
@@ -144,9 +148,10 @@ def init(model: TransformerModel, X=None, Y=None):
         token_data = huggingface_tokenize(tokenizer, [span.text for span in flat_spans])
         wordpieces = WordpieceBatch.from_batch_encoding(token_data)
         if "offset_mapping" in token_data:
+            offset_mapping: Any = token_data["offset_mapping"]
             align = get_alignment_via_offset_mapping(
                 flat_spans,
-                token_data["offset_mapping"],
+                offset_mapping,
             )
         else:
             align = get_alignment(
@@ -185,9 +190,10 @@ def forward(
     if "logger" in model.attrs:
         log_batch_size(model.attrs["logger"], wordpieces, is_train)
     if "offset_mapping" in batch_encoding:
+        offset_mapping: Any = batch_encoding["offset_mapping"]
         align = get_alignment_via_offset_mapping(
             flat_spans,
-            batch_encoding["offset_mapping"],
+            offset_mapping,
         )
     else:
         align = get_alignment(

--- a/spacy_transformers/layers/trfs2arrays.py
+++ b/spacy_transformers/layers/trfs2arrays.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Optional, Tuple, cast
 import numpy
 from spacy.util import all_equal
-from transformers.file_utils import ModelOutput
+from transformers.utils.generic import ModelOutput
 from transformers.modeling_outputs import BaseModelOutput
 from thinc.api import Model
 from thinc.types import Ragged, Floats2d
@@ -46,6 +46,7 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             )
         if "last_hidden_state" in trf_data.model_output:
             tensor_t_i = cast(BaseModelOutput, trf_data.model_output).last_hidden_state
+            assert tensor_t_i is not None
             if tensor_t_i.size == 0:
                 # This can happen during prediction/initialization if the transformer pipe was disabled/not executed and one of the inputs
                 # was of length zero. This causes the listenener to generate a zero-sized (in the sequence length dim) TransformerData
@@ -108,9 +109,9 @@ def forward(model: Model, trf_datas: List[TransformerData], is_train: bool):
             )
             d_src = get_d_src(d_output)
             d_src *= grad_factor
-            d_model_output["last_hidden_state"] = d_src.reshape(
-                cast(BaseModelOutput, trf_data.model_output).last_hidden_state.shape
-            )
+            _lhs = cast(BaseModelOutput, trf_data.model_output).last_hidden_state
+            assert _lhs is not None
+            d_model_output["last_hidden_state"] = d_src.reshape(_lhs.shape)
             d_trf_datas.append(
                 TransformerData(
                     model_output=d_model_output,

--- a/spacy_transformers/pipeline_component.py
+++ b/spacy_transformers/pipeline_component.py
@@ -6,7 +6,8 @@ from spacy.pipeline.pipe import deserialize_config
 from spacy.tokens import Doc
 from spacy.vocab import Vocab
 from spacy.training import Example, validate_examples
-from spacy import util, Errors
+from spacy import util
+from spacy.errors import Errors
 from spacy.util import minibatch
 from thinc.api import Model, Config, set_dropout_rate, Optimizer
 import srsly
@@ -284,9 +285,7 @@ class Transformer(TrainablePipe):
         validate_examples(examples, "Transformer.update")
         if losses is None:
             losses = {}
-        docs = [eg.predicted for eg in examples]
-        if isinstance(docs, Doc):
-            docs = [docs]
+        docs: List[Doc] = [eg.predicted for eg in examples]
         if not any(len(doc) for doc in docs):
             # Handle cases where there are no tokens in any docs.
             return losses
@@ -403,8 +402,8 @@ class Transformer(TrainablePipe):
                 p = Path(p).absolute()
                 hf_model = huggingface_from_pretrained(
                     p,
-                    self.model._init_tokenizer_config,
-                    self.model._init_transformer_config,
+                    self.model._init_tokenizer_config,  # type: ignore[attr-defined]
+                    self.model._init_transformer_config,  # type: ignore[attr-defined]
                 )
                 self.model.attrs["set_transformer"](self.model, hf_model)
 

--- a/spacy_transformers/truncate.py
+++ b/spacy_transformers/truncate.py
@@ -1,6 +1,6 @@
-from typing import Tuple, List, Union, TypeVar
+from typing import Tuple, List, Union, TypeVar, cast
 import numpy
-from thinc.types import Ragged, Ints2d, Floats2d
+from thinc.types import Ragged, Ints1d, Ints2d, Floats2d
 from .data_classes import WordpieceBatch
 
 ArrayT = TypeVar("ArrayT", bound=Union[Ints2d, Floats2d])
@@ -112,4 +112,4 @@ def _truncate_alignment(align: Ragged, mask: numpy.ndarray) -> Ragged:
     for i in range(len(align.lengths)):
         drops = ~mask[align[i].data.ravel()]
         new_lengths[i] -= drops.sum()
-    return Ragged(new_align, new_lengths)
+    return Ragged(cast(Ints1d, new_align), cast(Ints1d, new_lengths))

--- a/spacy_transformers/util.py
+++ b/spacy_transformers/util.py
@@ -2,10 +2,10 @@ from typing import List, Dict, Union, Set
 from pathlib import Path
 import random
 from transformers import AutoModel, AutoTokenizer
-from transformers.tokenization_utils import BatchEncoding
+from transformers.tokenization_utils_base import BatchEncoding
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 import catalogue
-from spacy.util import registry
+from spacy.util import registry as registry
 from thinc.api import get_torch_default_device
 import torch.cuda
 import tempfile


### PR DESCRIPTION
Update to latest transformers, safe-tensors and pyright.

This commit was prepared with AI assistance, and I'm not 100% on all the details. I've therefore incremented this to a major version.

I think it's worth going ahead despite the uncertainty because the previous version was basically stranded by the ecosystem moving forward, and model loading was using APIs that are now flagged as unsafe.

I've prepared a new model release `en_core_web_hftrf` that works with this version of the library.